### PR TITLE
Update spmm_csr_example.c

### DIFF
--- a/cuSPARSE/spmm_csr/spmm_csr_example.c
+++ b/cuSPARSE/spmm_csr/spmm_csr_example.c
@@ -145,7 +145,7 @@ int main(void) {
                                  CUSPARSE_OPERATION_NON_TRANSPOSE,
                                  &alpha, matA, matB, &beta, matC, CUDA_R_32F,
                                  CUSPARSE_MM_ALG_DEFAULT, &bufferSize) )
-    CHECK_CUSPARSE( cudaMalloc(&dBuffer, bufferSize) )
+    CHECK_CUDA( cudaMalloc(&dBuffer, bufferSize) )
 
     // execute SpMM
     CHECK_CUSPARSE( cusparseSpMM(handle,


### PR DESCRIPTION
There is a small mistake on the file. The function to check cudaMalloc should be CHECK_CUDA, not CHECK_SPARSE