### PR TITLE
[cuTENSOR] Fix a license resolve error.

### DIFF
--- a/cuTENSOR/python/cutensor/package_info.py
+++ b/cuTENSOR/python/cutensor/package_info.py
@@ -41,4 +41,4 @@ __package_name__ = 'cutensor-python'
 __description__ = 'PyTorch and Tensorflow Python bindings for cuTENSOR',
 __homepage__ = 'https://developer.nvidia.com/cutensor',
 __download_url__ = 'https://github.com/NVIDIA/CUDALibrarySamples/tree/master/cuTENSOR/cutensor',
-__license__ = 'BSD',
+__license__ = 'BSD'


### PR DESCRIPTION
# Problem description
When installing cuTENSOR with python extension (the Step 3 in [Installation](https://github.com/NVIDIA/CUDALibrarySamples/tree/master/cuTENSOR/python#installation) section) , the `pip install .` command returned error and cannot successfully install the package.

# Environment
NGC containers: nvcr.io/nvidia/pytorch:21.10-py3
it contains setuptools 58.2.0.

Manually upgrade setuptools to 59.5.0 was still not working.


# Error details
```
$ pip3 install .
Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
Processing /workspace/CUDALibrarySamples/cuTENSOR/python
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
    ERROR: Command errored out with exit status 1:
     command: /opt/conda/bin/python3.8 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-jugijbb4/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-jugijbb4/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-rlzoje3i
         cwd: /tmp/pip-req-build-jugijbb4/
    Complete output (26 lines):

# Redistribution and use in source and binary forms, with or without
    running egg_info
    creating /tmp/pip-pip-egg-info-rlzoje3i/cutensor_python.egg-info
    writing /tmp/pip-pip-egg-info-rlzoje3i/cutensor_python.egg-info/PKG-INFO
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-jugijbb4/setup.py", line 43, in <module>
        setup(name=__package_name__,
      File "/opt/conda/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/opt/conda/lib/python3.8/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/opt/conda/lib/python3.8/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/opt/conda/lib/python3.8/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/opt/conda/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 292, in run
        writer(self, ep.name, os.path.join(self.egg_info, ep.name))
      File "/opt/conda/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/opt/conda/lib/python3.8/distutils/dist.py", line 1117, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/opt/conda/lib/python3.8/site-packages/setuptools/dist.py", line 185, in write_pkg_file
        license = rfc822_escape(self.get_license())
      File "/opt/conda/lib/python3.8/distutils/util.py", line 475, in rfc822_escape
        lines = header.split('\n')
    AttributeError: 'tuple' object has no attribute 'split'
    ----------------------------------------
```

# Root cause
the `__license__` variable is a tuple `'BSD',`, and this tuple contains one element, the element is string type.
While setuptools expect the license should be one string (aka, `'BSD'` )

# Possible solution
Remove the comma in the last, to make the variable as a single string.