### PR TITLE
fix typo in cublas_gemm_example.cu comments

### DIFF
--- a/cuBLAS/Level-3/gemm/cublas_gemm_example.cu
+++ b/cuBLAS/Level-3/gemm/cublas_gemm_example.cu
@@ -69,11 +69,11 @@ int main(int argc, char *argv[]) {
     const int ldb = 2;
     const int ldc = 2;
     /*
-     *   A = | 1.0 | 2.0 |
-     *       | 3.0 | 4.0 |
+     *   A = | 1.0 | 3.0 |
+     *       | 2.0 | 4.0 |
      *
-     *   B = | 5.0 | 6.0 |
-     *       | 7.0 | 8.0 |
+     *   B = | 5.0 | 7.0 |
+     *       | 6.0 | 8.0 |
      */
 
     const std::vector<data_type> A = {1.0, 2.0, 3.0, 4.0};


### PR DESCRIPTION
Since CUBLAS uses column-major order, a 1D vector initialized as {1,2,3,4} should be interpreted as the matrix 
|1 3|
|2 4|.
This is confirmed by the cuda output:
|1 3|     |5 7|   |23 31|
|2 4| dot |6 8| = |34 46|