### PR TITLE
cuTENSORMg sample: Change seconds to milliseconds

### DIFF
--- a/cuTENSORMg/contraction_multi_gpu.cu
+++ b/cuTENSORMg/contraction_multi_gpu.cu
@@ -325,7 +325,7 @@ int main(int argc, char** argv)
     }
     CHECK(cudaSetDevice(currentDeviceId));
 
-    printf("execution took: %.2e sec.\n", minElapsed);
+    printf("execution took: %.2e ms.\n", minElapsed);
 
     printf("Free resources ...\n");
 


### PR DESCRIPTION
This pull request is a minor fix for the timer printout, which mistakenly writes "sec" while the result is in milliseconds.