### PR TITLE
Include sstream

### DIFF
--- a/nvJPEG2000/nvJPEG2000-Encoder/nvjpeg2k_encode.cpp
+++ b/nvJPEG2000/nvJPEG2000-Encoder/nvjpeg2k_encode.cpp
@@ -28,6 +28,7 @@
 
 #include "nvjpeg2k_encode.h"
 #include <cmath>
+#include <sstream>
 
 struct bmpHeader
 {


### PR DESCRIPTION
istringstream is used without #include <sstream> and hence doesn't build on Windows