### PR TITLE
fix batchgemmedex compile err in linux

### DIFF
--- a/cuBLAS/Extensions/GemmBatchedEx/cublas_GemmBatchedEx_example.cu
+++ b/cuBLAS/Extensions/GemmBatchedEx/cublas_GemmBatchedEx_example.cu
@@ -153,9 +153,9 @@ int main(int argc, char *argv[]) {
                                cudaMemcpyHostToDevice, stream));
 
     /* step 3: compute */
-    CUBLAS_CHECK(cublasGemmBatchedEx(cublasH, transa, transb, m, n, k, &alpha, d_A_array,
-                                     traits<data_type>::cuda_data_type, lda, d_B_array,
-                                     traits<data_type>::cuda_data_type, ldb, &beta, d_C_array,
+    CUBLAS_CHECK(cublasGemmBatchedEx(cublasH, transa, transb, m, n, k, &alpha, (const void**)d_A_array,
+                                     traits<data_type>::cuda_data_type, lda, (const void**)d_B_array,
+                                     traits<data_type>::cuda_data_type, ldb, &beta, (void**)d_C_array,
                                      traits<data_type>::cuda_data_type, ldc, batch_count,
                                      compute_type, CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 


### PR DESCRIPTION
Using the default code 4 GemmBatchedEx in a linux environment will cause err in a parameter list.
<img width="851" alt="image" src="https://github.com/NVIDIA/CUDALibrarySamples/assets/104877312/0af592b2-7b8c-4627-9280-a1982b953e44">
This pr simply modifies the relevant parameter list to make it compileable.