### PR TITLE
CUBLAS readme fixes

### DIFF
--- a/cuBLAS/Extensions/dgmm/README.md
+++ b/cuBLAS/Extensions/dgmm/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dgmm() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dgmm)
+- [cublas\<t>dgmm() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dgmm)
 
 # Building (make)
 

--- a/cuBLAS/Extensions/geam/README.md
+++ b/cuBLAS/Extensions/geam/README.md
@@ -1,8 +1,8 @@
-# cuBLAS Extension APIs - `cublas<t>dgmm`
+# cuBLAS Extension APIs - `cublas<t>dgeam`
 
 ## Description
 
-This code demonstrates a usage of cuBLAS `dgmm` function to matrix-matrix multiplication
+This code demonstrates a usage of cuBLAS `dgeam` function for matrix-matrix addition
 
 ```
 A = | 1.0 | 2.0 |
@@ -16,21 +16,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dgmm() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dgmm)
+- [cublas\<t>dgeam() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-geam)
 
 # Building (make)
 
@@ -64,15 +64,15 @@ Sample example output:
 
 ```
 A
-1.00 2.00 
-3.00 4.00 
+1.00 2.00
+3.00 4.00
 =====
 B
-5.00 6.00 
-7.00 8.00 
+5.00 6.00
+7.00 8.00
 =====
 C
-11.00 14.00 
-17.00 20.00 
+11.00 14.00
+17.00 20.00
 =====
 ```

--- a/cuBLAS/Extensions/geam/README.md
+++ b/cuBLAS/Extensions/geam/README.md
@@ -1,8 +1,8 @@
-# cuBLAS Extension APIs - `cublas<t>dgmm`
+# cuBLAS Extension APIs - `cublas<t>geam`
 
 ## Description
 
-This code demonstrates a usage of cuBLAS `dgmm` function to matrix-matrix multiplication
+This code demonstrates a usage of cuBLAS `geam` function to matrix-matrix addition
 
 ```
 A = | 1.0 | 2.0 |
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dgmm() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dgmm)
+- [cublas\<t>geam() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-geam)
 
 # Building (make)
 
@@ -57,7 +57,7 @@ $ Open cublas_examples.sln project in Visual Studio and build
 
 # Usage
 ```
-$  ./cublas_dgmm_example
+$  ./cublas_geam_example
 ```
 
 Sample example output:

--- a/cuBLAS/Extensions/geam/README.md
+++ b/cuBLAS/Extensions/geam/README.md
@@ -1,8 +1,8 @@
-# cuBLAS Extension APIs - `cublas<t>dgeam`
+# cuBLAS Extension APIs - `cublas<t>dgmm`
 
 ## Description
 
-This code demonstrates a usage of cuBLAS `dgeam` function for matrix-matrix addition
+This code demonstrates a usage of cuBLAS `dgmm` function to matrix-matrix multiplication
 
 ```
 A = | 1.0 | 2.0 |
@@ -16,21 +16,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dgeam() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-geam)
+- [cublas\<t>dgmm() API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dgmm)
 
 # Building (make)
 
@@ -64,15 +64,15 @@ Sample example output:
 
 ```
 A
-1.00 2.00
-3.00 4.00
+1.00 2.00 
+3.00 4.00 
 =====
 B
-5.00 6.00
-7.00 8.00
+5.00 6.00 
+7.00 8.00 
 =====
 C
-11.00 14.00
-17.00 20.00
+11.00 14.00 
+17.00 20.00 
 =====
 ```

--- a/cuBLAS/Level-1/amax/README.md
+++ b/cuBLAS/Level-1/amax/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>amax API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-amax)
+- [cublas\<t>amax API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-amax)
 
 # Building (make)
 
@@ -60,7 +60,7 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 result
 4

--- a/cuBLAS/Level-1/amax/README.md
+++ b/cuBLAS/Level-1/amax/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>amax API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-amax)
+- [cublas\<t>amax API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-amax)
 
 # Building (make)
 
@@ -60,7 +60,7 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 result
 4

--- a/cuBLAS/Level-1/amax/README.md
+++ b/cuBLAS/Level-1/amax/README.md
@@ -26,7 +26,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>amax API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-amax)
+- [cublas\<t>amax API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-amax)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/amin/README.md
+++ b/cuBLAS/Level-1/amin/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>amin API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-amin)
+- [cublas\<t>amin API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-amin)
 
 # Building (make)
 
@@ -60,7 +60,7 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 result
 1

--- a/cuBLAS/Level-1/amin/README.md
+++ b/cuBLAS/Level-1/amin/README.md
@@ -26,7 +26,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>amin API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-amin)
+- [cublas\<t>amin API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-amin)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/amin/README.md
+++ b/cuBLAS/Level-1/amin/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>amin API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-amin)
+- [cublas\<t>amin API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-amin)
 
 # Building (make)
 
@@ -60,7 +60,7 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 result
 1

--- a/cuBLAS/Level-1/asum/README.md
+++ b/cuBLAS/Level-1/asum/README.md
@@ -26,7 +26,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>asum API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-asum)
+- [cublas\<t>asum API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-t-asum)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/asum/README.md
+++ b/cuBLAS/Level-1/asum/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>asum API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-asum)
+- [cublas\<t>asum API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-asum)
 
 # Building (make)
 
@@ -60,7 +60,7 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 result
 10.00

--- a/cuBLAS/Level-1/asum/README.md
+++ b/cuBLAS/Level-1/asum/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>asum API](https://docs.nvidia.com/cuda/cublas/index.html#cublasi-lt-t-gt-asum)
+- [cublas\<t>asum API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-asum)
 
 # Building (make)
 
@@ -60,7 +60,7 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 result
 10.00

--- a/cuBLAS/Level-1/axpy/README.md
+++ b/cuBLAS/Level-1/axpy/README.md
@@ -15,21 +15,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>axpy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-axpy)
+- [cublas\<t>axpy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-axpy)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/axpy/README.md
+++ b/cuBLAS/Level-1/axpy/README.md
@@ -15,21 +15,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>axpy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-axpy)
+- [cublas\<t>axpy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-axpy)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/axpy/README.md
+++ b/cuBLAS/Level-1/axpy/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>axpy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-axpy)
+- [cublas\<t>axpy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-axpy)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/copy/README.md
+++ b/cuBLAS/Level-1/copy/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>copy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-copy)
+- [cublas\<t>copy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-copy)
 
 # Building (make)
 
@@ -60,13 +60,13 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 B
-0.00 0.00 0.00 0.00 
+0.00 0.00 0.00 0.00
 =====
 B
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 
 ```

--- a/cuBLAS/Level-1/copy/README.md
+++ b/cuBLAS/Level-1/copy/README.md
@@ -12,21 +12,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>copy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-copy)
+- [cublas\<t>copy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-copy)
 
 # Building (make)
 
@@ -60,13 +60,13 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 B
-0.00 0.00 0.00 0.00
+0.00 0.00 0.00 0.00 
 =====
 B
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 
 ```

--- a/cuBLAS/Level-1/copy/README.md
+++ b/cuBLAS/Level-1/copy/README.md
@@ -26,7 +26,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>copy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-copy)
+- [cublas\<t>copy API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-copy)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/dot/README.md
+++ b/cuBLAS/Level-1/dot/README.md
@@ -21,22 +21,22 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dot  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dot)
-- [cublas\<t>dotc  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dot)
+- [cublas\<t>dot  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot)
+- [cublas\<t>dotc  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/dot/README.md
+++ b/cuBLAS/Level-1/dot/README.md
@@ -35,8 +35,8 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dot  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot)
-- [cublas\<t>dotc  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot)
+- [cublas\<t>dot  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dot)
+- [cublas\<t>dotc  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dot)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/dot/README.md
+++ b/cuBLAS/Level-1/dot/README.md
@@ -21,22 +21,22 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>dot  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot)
-- [cublas\<t>dotc  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot)
+- [cublas\<t>dot  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dot)
+- [cublas\<t>dotc  API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-dot)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/nrm2/README.md
+++ b/cuBLAS/Level-1/nrm2/README.md
@@ -6,27 +6,27 @@ This code demonstrates a usage of cuBLAS `nrm2` function to compute the Euclidea
 
 ```
 A = | 1.0 | 2.0 | 3.0 | 4.0 |
-```
+``` 
 
 See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>nrm2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-nrm2)
+- [cublas\<t>nrm2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-nrm2)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/nrm2/README.md
+++ b/cuBLAS/Level-1/nrm2/README.md
@@ -6,27 +6,27 @@ This code demonstrates a usage of cuBLAS `nrm2` function to compute the Euclidea
 
 ```
 A = | 1.0 | 2.0 | 3.0 | 4.0 |
-``` 
+```
 
 See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>nrm2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-nrm2)
+- [cublas\<t>nrm2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-nrm2)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/nrm2/README.md
+++ b/cuBLAS/Level-1/nrm2/README.md
@@ -26,7 +26,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>nrm2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-nrm2)
+- [cublas\<t>nrm2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-nrm2)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rot/README.md
+++ b/cuBLAS/Level-1/rot/README.md
@@ -27,7 +27,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rot API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rot)
+- [cublas\<t>rot API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rot)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rot/README.md
+++ b/cuBLAS/Level-1/rot/README.md
@@ -13,21 +13,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rot API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rot)
+- [cublas\<t>rot API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rot)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rot/README.md
+++ b/cuBLAS/Level-1/rot/README.md
@@ -13,21 +13,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rot API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rot)
+- [cublas\<t>rot API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rot)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rotg/README.md
+++ b/cuBLAS/Level-1/rotg/README.md
@@ -15,21 +15,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotg)
+- [cublas\<t>rotg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotg)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rotg/README.md
+++ b/cuBLAS/Level-1/rotg/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotg)
+- [cublas\<t>rotg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotg)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rotg/README.md
+++ b/cuBLAS/Level-1/rotg/README.md
@@ -15,21 +15,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotg)
+- [cublas\<t>rotg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotg)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rotm/README.md
+++ b/cuBLAS/Level-1/rotm/README.md
@@ -13,21 +13,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotm)
+- [cublas\<t>rotm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotm)
 
 # Building (make)
 
@@ -61,18 +61,18 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 B
-5.00 6.00 7.00 8.00 
+5.00 6.00 7.00 8.00
 =====
 param
-1.00 5.00 6.00 7.00 8.00 
+1.00 5.00 6.00 7.00 8.00
 =====
 A
-10.00 16.00 22.00 28.00 
+10.00 16.00 22.00 28.00
 =====
 B
-39.00 46.00 53.00 60.00 
+39.00 46.00 53.00 60.00
 =====
 ```

--- a/cuBLAS/Level-1/rotm/README.md
+++ b/cuBLAS/Level-1/rotm/README.md
@@ -27,7 +27,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotm)
+- [cublas\<t>rotm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotm)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rotm/README.md
+++ b/cuBLAS/Level-1/rotm/README.md
@@ -13,21 +13,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotm)
+- [cublas\<t>rotm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotm)
 
 # Building (make)
 
@@ -61,18 +61,18 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 B
-5.00 6.00 7.00 8.00
+5.00 6.00 7.00 8.00 
 =====
 param
-1.00 5.00 6.00 7.00 8.00
+1.00 5.00 6.00 7.00 8.00 
 =====
 A
-10.00 16.00 22.00 28.00
+10.00 16.00 22.00 28.00 
 =====
 B
-39.00 46.00 53.00 60.00
+39.00 46.00 53.00 60.00 
 =====
 ```

--- a/cuBLAS/Level-1/rotmg/README.md
+++ b/cuBLAS/Level-1/rotmg/README.md
@@ -13,21 +13,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotmg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotmg)
+- [cublas\<t>rotmg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotmg)
 
 # Building (make)
 
@@ -73,7 +73,7 @@ Y
 1.20
 =====
 param
-1.00 5.00 6.00 7.00 8.00 
+1.00 5.00 6.00 7.00 8.00
 =====
 A
 3.10

--- a/cuBLAS/Level-1/rotmg/README.md
+++ b/cuBLAS/Level-1/rotmg/README.md
@@ -27,7 +27,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotmg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotmg)
+- [cublas\<t>rotmg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotmg)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/rotmg/README.md
+++ b/cuBLAS/Level-1/rotmg/README.md
@@ -13,21 +13,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>rotmg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-rotmg)
+- [cublas\<t>rotmg API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-rotmg)
 
 # Building (make)
 
@@ -73,7 +73,7 @@ Y
 1.20
 =====
 param
-1.00 5.00 6.00 7.00 8.00
+1.00 5.00 6.00 7.00 8.00 
 =====
 A
 3.10

--- a/cuBLAS/Level-1/scal/README.md
+++ b/cuBLAS/Level-1/scal/README.md
@@ -6,7 +6,7 @@ This code demonstrates a usage of cuBLAS `scal` function to compute the product 
 
 ```
 A = | 1.0 | 2.0 | 3.0 | 4.0 |
-```
+``` 
 
 This function scales the vector _x_ by the scalar α and overwrites it with the result
 
@@ -14,21 +14,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>scal API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-scal)
+- [cublas\<t>scal API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-scal)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/scal/README.md
+++ b/cuBLAS/Level-1/scal/README.md
@@ -6,7 +6,7 @@ This code demonstrates a usage of cuBLAS `scal` function to compute the product 
 
 ```
 A = | 1.0 | 2.0 | 3.0 | 4.0 |
-``` 
+```
 
 This function scales the vector _x_ by the scalar α and overwrites it with the result
 
@@ -14,21 +14,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>scal API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-scal)
+- [cublas\<t>scal API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-scal)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/scal/README.md
+++ b/cuBLAS/Level-1/scal/README.md
@@ -28,7 +28,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>scal API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-scal)
+- [cublas\<t>scal API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-scal)
 
 # Building (make)
 

--- a/cuBLAS/Level-1/swap/README.md
+++ b/cuBLAS/Level-1/swap/README.md
@@ -14,21 +14,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
 
 ## Supported OSes
 
-Linux  
+Linux
 Windows
 
 ## Supported CPU Architecture
 
-x86_64  
-ppc64le  
+x86_64
+ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>swap API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-swap)
+- [cublas\<t>swap API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-swap)
 
 # Building (make)
 
@@ -62,15 +62,15 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 B
-5.00 6.00 7.00 8.00 
+5.00 6.00 7.00 8.00
 =====
 A
-5.00 6.00 7.00 8.00 
+5.00 6.00 7.00 8.00
 =====
 B
-1.00 2.00 3.00 4.00 
+1.00 2.00 3.00 4.00
 =====
 ```

--- a/cuBLAS/Level-1/swap/README.md
+++ b/cuBLAS/Level-1/swap/README.md
@@ -14,21 +14,21 @@ See documentation for further details.
 
 ## Supported SM Architectures
 
-All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)
+All GPUs supported by CUDA Toolkit (https://developer.nvidia.com/cuda-gpus)  
 
 ## Supported OSes
 
-Linux
+Linux  
 Windows
 
 ## Supported CPU Architecture
 
-x86_64
-ppc64le
+x86_64  
+ppc64le  
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>swap API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-swap)
+- [cublas\<t>swap API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-swap)
 
 # Building (make)
 
@@ -62,15 +62,15 @@ Sample example output:
 
 ```
 A
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 B
-5.00 6.00 7.00 8.00
+5.00 6.00 7.00 8.00 
 =====
 A
-5.00 6.00 7.00 8.00
+5.00 6.00 7.00 8.00 
 =====
 B
-1.00 2.00 3.00 4.00
+1.00 2.00 3.00 4.00 
 =====
 ```

--- a/cuBLAS/Level-1/swap/README.md
+++ b/cuBLAS/Level-1/swap/README.md
@@ -28,7 +28,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>swap API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-swap)
+- [cublas\<t>swap API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-swap)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/gbmv/README.md
+++ b/cuBLAS/Level-2/gbmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>gbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gbmv)
+- [cublas\<t>gbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gbmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/gemv/README.md
+++ b/cuBLAS/Level-2/gemv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>gemv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemv)
+- [cublas\<t>gemv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/ger/README.md
+++ b/cuBLAS/Level-2/ger/README.md
@@ -31,7 +31,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>ger API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-ger)
+- [cublas\<t>ger API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-ger)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/hbmv/README.md
+++ b/cuBLAS/Level-2/hbmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>hbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-hbmv)
+- [cublas\<t>hbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-hbmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/hemv/README.md
+++ b/cuBLAS/Level-2/hemv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>hemv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-hemv)
+- [cublas\<t>hemv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-hemv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/her/README.md
+++ b/cuBLAS/Level-2/her/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>her API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-her)
+- [cublas\<t>her API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-her)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/her2/README.md
+++ b/cuBLAS/Level-2/her2/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>her2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-her2)
+- [cublas\<t>her2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-her2)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/hpmv/README.md
+++ b/cuBLAS/Level-2/hpmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>hpmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-hpmv)
+- [cublas\<t>hpmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-hpmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/hpr/README.md
+++ b/cuBLAS/Level-2/hpr/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>hpr API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-hpr)
+- [cublas\<t>hpr API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-hpr)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/hpr2/README.md
+++ b/cuBLAS/Level-2/hpr2/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>hpr2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-hpr2)
+- [cublas\<t>hpr2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-hpr2)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/sbmv/README.md
+++ b/cuBLAS/Level-2/sbmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>sbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-sbmv)
+- [cublas\<t>sbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-sbmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/spmv/README.md
+++ b/cuBLAS/Level-2/spmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>spmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-spmv)
+- [cublas\<t>spmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-spmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/spr/README.md
+++ b/cuBLAS/Level-2/spr/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>spr API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-spr)
+- [cublas\<t>spr API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-spr)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/spr2/README.md
+++ b/cuBLAS/Level-2/spr2/README.md
@@ -31,7 +31,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>spr2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-spr2)
+- [cublas\<t>spr2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-spr2)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/symv/README.md
+++ b/cuBLAS/Level-2/symv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>symv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-symv)
+- [cublas\<t>symv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-symv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/syr/README.md
+++ b/cuBLAS/Level-2/syr/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>syr API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-syr)
+- [cublas\<t>syr API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-syr)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/syr2/README.md
+++ b/cuBLAS/Level-2/syr2/README.md
@@ -31,7 +31,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>syr2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-syr2)
+- [cublas\<t>syr2 API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-syr2)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/tbmv/README.md
+++ b/cuBLAS/Level-2/tbmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>tbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-tbmv)
+- [cublas\<t>tbmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-tbmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/tbsv/README.md
+++ b/cuBLAS/Level-2/tbsv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>tbsv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-tbsv)
+- [cublas\<t>tbsv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-tbsv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/tpmv/README.md
+++ b/cuBLAS/Level-2/tpmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>tpmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-tpmv)
+- [cublas\<t>tpmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-tpmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/tpsv/README.md
+++ b/cuBLAS/Level-2/tpsv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>tpsv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-tpsv)
+- [cublas\<t>tpsv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-tpsv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/trmv/README.md
+++ b/cuBLAS/Level-2/trmv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>trmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-trmv)
+- [cublas\<t>trmv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-trmv)
 
 # Building (make)
 

--- a/cuBLAS/Level-2/trsv/README.md
+++ b/cuBLAS/Level-2/trsv/README.md
@@ -29,7 +29,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>trsv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-trsv)
+- [cublas\<t>trsv API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-trsv)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/gemm/README.md
+++ b/cuBLAS/Level-3/gemm/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>gemm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm)
+- [cublas\<t>gemm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemm)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/gemm3m/README.md
+++ b/cuBLAS/Level-3/gemm3m/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>gemm3m API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm3m)
+- [cublas\<t>gemm3m API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemm3m)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/gemmBatched/README.md
+++ b/cuBLAS/Level-3/gemmBatched/README.md
@@ -32,7 +32,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>gemmBatched API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemmbatched)
+- [cublas\<t>gemmBatched API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemmbatched)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/gemmStridedBatched/README.md
+++ b/cuBLAS/Level-3/gemmStridedBatched/README.md
@@ -32,7 +32,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>gemmStridedBatched API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemmstridedbatched)
+- [cublas\<t>gemmStridedBatched API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemmstridedbatched)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/hemm/README.md
+++ b/cuBLAS/Level-3/hemm/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>hemm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-hemm)
+- [cublas\<t>hemm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-hemm)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/her2k/README.md
+++ b/cuBLAS/Level-3/her2k/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>her2k API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-her2k)
+- [cublas\<t>her2k API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-her2k)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/herk/README.md
+++ b/cuBLAS/Level-3/herk/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>herk API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-herk)
+- [cublas\<t>herk API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-herk)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/herkx/README.md
+++ b/cuBLAS/Level-3/herkx/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>herkx API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-herkx)
+- [cublas\<t>herkx API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-herkx)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/symm/README.md
+++ b/cuBLAS/Level-3/symm/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>symm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-symm)
+- [cublas\<t>symm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-symm)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/syr2k/README.md
+++ b/cuBLAS/Level-3/syr2k/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>syr2k API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-syr2k)
+- [cublas\<t>syr2k API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-syr2k)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/syrk/README.md
+++ b/cuBLAS/Level-3/syrk/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>syrk API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-syrk)
+- [cublas\<t>syrk API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-syrk)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/syrkx/README.md
+++ b/cuBLAS/Level-3/syrkx/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>syrkx API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-syrkx)
+- [cublas\<t>syrkx API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-syrkx)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/trmm/README.md
+++ b/cuBLAS/Level-3/trmm/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>trmm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-trmm)
+- [cublas\<t>trmm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-trmm)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/trsm/README.md
+++ b/cuBLAS/Level-3/trsm/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>trsm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-trsm)
+- [cublas\<t>trsm API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-trsm)
 
 # Building (make)
 

--- a/cuBLAS/Level-3/trsmBatched/README.md
+++ b/cuBLAS/Level-3/trsmBatched/README.md
@@ -30,7 +30,7 @@ ppc64le
 arm64-sbsa
 
 ## CUDA APIs involved
-- [cublas\<t>trsmBatched API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-trsmBatched)
+- [cublas\<t>trsmBatched API](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-trsmBatched)
 
 # Building (make)
 


### PR DESCRIPTION
Fix #88. Also fix broken links.
The documentation links did not have correct header names, and was thus redirecting to the start of the CUBLAS documentation instead of the function documentation.

My editor automatically removes the trailing whitespaces. Sorry if it makes the git diff harder to read.
Are these trailing whitespaces important? It did not look so to me.