### PR TITLE
Fix typos in CMakeLists.txt files

### DIFF
--- a/cuSPARSE/coosort/CMakeLists.txt
+++ b/cuSPARSE/coosort/CMakeLists.txt
@@ -56,7 +56,7 @@ project("${ROUTINE}_example"
 add_executable(${ROUTINE}_example)
 
 target_sources(${ROUTINE}_example
-    PUBLIC ${PROJECT_SOURCE_DIR}/${ROUTINE}_example.cu
+    PUBLIC ${PROJECT_SOURCE_DIR}/${ROUTINE}_example.c
 )
 
 target_include_directories(${ROUTINE}_example

--- a/cuSPARSE/gpsvInterleavedBatch/CMakeLists.txt
+++ b/cuSPARSE/gpsvInterleavedBatch/CMakeLists.txt
@@ -56,7 +56,7 @@ project("${ROUTINE}_example"
 add_executable(${ROUTINE}_example)
 
 target_sources(${ROUTINE}_example
-    PUBLIC ${PROJECT_SOURCE_DIR}/${ROUTINE}_example.cu
+    PUBLIC ${PROJECT_SOURCE_DIR}/${ROUTINE}_example.c
 )
 
 target_include_directories(${ROUTINE}_example


### PR DESCRIPTION
Fix typos in file names in `cuSPARSE/gpsvInterleavedBatch/CMakeLists.txt` and `cuSPARSE/coosort/CMakeLists.txt`