### PR TITLE
Correct cufft_utils scaling_kernel indexing

### DIFF
--- a/cuFFT/utils/cufft_utils.h
+++ b/cuFFT/utils/cufft_utils.h
@@ -89,7 +89,7 @@ void scaling_kernel(cufftComplex* data, int element_count, float scale) {
     const int tid = threadIdx.x + blockIdx.x * blockDim.x;
     const int stride = blockDim.x * gridDim.x;
     for (auto i = tid; i<element_count; i+= stride) {
-        data[tid].x *= scale;
-        data[tid].y *= scale;
+        data[i].x *= scale;
+        data[i].y *= scale;
     }
 }


### PR DESCRIPTION
The scaling_kernel is clearly designed to be a grid-stride kernel to multiply all elements by a constant; this makes it so.

While the examples will build and run correctly as-is, if the parameters are changed (like in 1d_r2c_c2r) to be a larger value, it becomes highly likely that the output will be wrong, as only a few elements will be 'scaled' multiple times.