### PR TITLE
Add a sample code for reading an input matrix market file for a simple cuDSS resolution

### DIFF
--- a/cuDSS/simple/simple.cpp
+++ b/cuDSS/simple/simple.cpp
@@ -123,7 +123,7 @@ int main (int argc, char *argv[]) {
     double *x_values_d = NULL, *b_values_d = NULL;
 
     /* Allocate host memory for the sparse input matrix A,
-       right-hand side x and solution b*/
+       right-hand side b and solution x*/
 
     csr_offsets_h = (int*)malloc((n + 1) * sizeof(int));
     csr_columns_h = (int*)malloc(nnz * sizeof(int));

--- a/cuDSS/simple_matrix_market/CMakeLists.txt
+++ b/cuDSS/simple_matrix_market/CMakeLists.txt
@@ -1,0 +1,108 @@
+#
+# Copyright 2023-2025 NVIDIA Corporation.  All rights reserved.
+#
+# NOTICE TO LICENSEE:
+#
+# This source code and/or documentation ("Licensed Deliverables") are
+# subject to NVIDIA intellectual property rights under U.S. and
+# international Copyright laws.
+#
+# These Licensed Deliverables contained herein is PROPRIETARY and
+# CONFIDENTIAL to NVIDIA and is being provided under the terms and
+# conditions of a form of NVIDIA software license agreement by and
+# between NVIDIA and Licensee ("License Agreement") or electronically
+# accepted by Licensee.  Notwithstanding any terms or conditions to
+# the contrary in the License Agreement, reproduction or disclosure
+# of the Licensed Deliverables to any third party without the express
+# written consent of NVIDIA is prohibited.
+#
+# NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+# LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
+# SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
+# PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF ANY KIND.
+# NVIDIA DISCLAIMS ALL WARRANTIES WITH REGARD TO THESE LICENSED
+# DELIVERABLES, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY,
+# NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+# NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+# LICENSE AGREEMENT, IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY
+# SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THESE LICENSED DELIVERABLES.
+#
+# U.S. Government End Users.  These Licensed Deliverables are a
+# "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
+# 1995), consisting of "commercial computer software" and "commercial
+# computer software documentation" as such terms are used in 48
+# C.F.R. 12.212 (SEPT 1995) and is provided to the U.S. Government
+# only as a commercial end item.  Consistent with 48 C.F.R.12.212 and
+# 48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
+# U.S. Government End Users acquire the Licensed Deliverables with
+# only those rights set forth herein.
+#
+# Any use of the Licensed Deliverables in individual and commercial
+# software must include, in the user documentation and internal
+# comments to the code, the above Disclaimer and U.S. Government End
+# Users Notice.
+#
+cmake_minimum_required(VERSION 3.19)
+
+set(EXAMPLE_NAME  simple_matrix_market)
+
+project("cuDSS_${EXAMPLE_NAME}_example"
+        DESCRIPTION  "cuDSS"
+        HOMEPAGE_URL "https://docs.nvidia.com/cuda/cudss/index.html"
+        LANGUAGES    CXX CUDA)
+
+set(CMAKE_CUDA_STANDARD          11)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_EXTENSIONS        OFF)
+
+option(BUILD_STATIC "Building statically linked examples" OFF)
+
+# Find cuDSS
+find_package(cudss 0.5.0 REQUIRED)
+
+set_source_files_properties(${EXAMPLE_NAME}.cpp PROPERTIES LANGUAGE CUDA)
+
+add_executable(${EXAMPLE_NAME}_example)
+
+target_sources(${EXAMPLE_NAME}_example
+    PUBLIC ${PROJECT_SOURCE_DIR}/${EXAMPLE_NAME}.cpp
+)
+
+if (WIN32)
+    target_include_directories(${EXAMPLE_NAME}_example PUBLIC ${cudss_INCLUDE_DIR})
+    target_link_directories(${EXAMPLE_NAME}_example PUBLIC ${cudss_LIBRARY_DIR})
+endif()
+
+target_compile_options(${EXAMPLE_NAME}_example PRIVATE
+    "$<$<CONFIG:Debug>:-lineinfo -g>"
+    "$<$<CONFIG:RelWithDebInfo>:-lineinfo -g>"
+)
+
+target_link_libraries(${EXAMPLE_NAME}_example PUBLIC
+    cudss
+)
+
+if(BUILD_STATIC)
+    add_executable(${EXAMPLE_NAME}_example_static)
+
+    target_sources(${EXAMPLE_NAME}_example_static
+        PUBLIC ${PROJECT_SOURCE_DIR}/${EXAMPLE_NAME}.cpp
+    )
+
+    if (WIN32)
+        target_include_directories(${EXAMPLE_NAME}_example_static PUBLIC ${cudss_INCLUDE_DIR})
+        target_link_directories(${EXAMPLE_NAME}_example_static PUBLIC ${cudss_LIBRARY_DIR})
+        target_link_libraries(${EXAMPLE_NAME}_example_static PUBLIC
+        cudss
+    )
+    else()
+        target_link_libraries(${EXAMPLE_NAME}_example_static PUBLIC
+            cudss_static
+        )
+    endif()
+
+endif()

--- a/cuDSS/simple_matrix_market/matrix.mtx
+++ b/cuDSS/simple_matrix_market/matrix.mtx
@@ -1,0 +1,11 @@
+%%MatrixMarket matrix coordinate real general
+% 5x5 matrix with 8 non-zero entries in coordinate format
+5 5 8
+1 1 4.0
+1 3 1.0
+2 2 3.0
+2 3 2.0
+3 3 5.0
+3 5 1.0
+4 4 1.0
+5 5 2.0

--- a/cuDSS/simple_matrix_market/matrix_market_reader.h
+++ b/cuDSS/simple_matrix_market/matrix_market_reader.h
@@ -1,0 +1,96 @@
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+template <typename _TYPE_>
+void matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
+                   int** csr_columns_h, _TYPE_** csr_values_h) {
+    
+    std::ifstream file(filename);  // Open file for reading
+
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open file " << filename << std::endl;
+    }
+
+    std::string line;
+    int i_val = 0;
+    int i_offsets = 0;
+    int cumulative_nnz = 0;
+    int previous_line = -1;
+    bool foundSize = false;
+
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '%') continue;
+
+        std::istringstream lineData(line);
+
+        if (!foundSize) {
+            int n1;
+            lineData >> n >> n1 >> nnz;
+            std::cout << "MATRIX READER: n0= " << n << ", n1= " << n1 << ", nnz= " << nnz << "\n";
+
+            *csr_offsets_h = (int*)malloc((n + 1) * sizeof(int));
+            *csr_columns_h = (int*)malloc(nnz * sizeof(int));
+            *csr_values_h = (_TYPE_*)malloc(nnz * sizeof(_TYPE_));
+            std::cout << "MATRIX READER: allocated memory\n";
+
+            foundSize = true;
+        } else {
+            int i, j;
+            _TYPE_ val;
+            lineData >> i >> j >> val;
+
+            if (i > previous_line) {
+                (*csr_offsets_h)[i_offsets++] = cumulative_nnz;
+                previous_line = i;
+            }
+
+            (*csr_columns_h)[i_val] =
+                j - 1;  //-1 because mtx indexing is fortran like
+            (*csr_values_h)[i_val++] = val;
+            cumulative_nnz += 1;
+        }
+    }
+
+    (*csr_offsets_h)[i_offsets++] = cumulative_nnz;
+    if (cumulative_nnz != nnz) {
+        std::cerr << "READER: Error: nnz != cumulative_nnz" << std::endl;
+    }
+    file.close();  // Optional; automatic when `file` goes out of scope
+}
+
+template <typename _TYPE_>
+void rhs_reader(std::string filename, int& n, _TYPE_** b_values_h) {
+    std::ifstream file(filename);
+
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open file " << filename << std::endl;
+        return;
+    }
+
+    std::string line;
+    bool foundSize = false;
+
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '%') continue;
+
+        std::istringstream lineData(line);
+
+        if (!foundSize) {
+            int dummy0, dummy1;
+            lineData >> n >> dummy0 >> dummy1;
+            *b_values_h = (_TYPE_*)malloc(n * sizeof(_TYPE_));
+            std::cout << "VECTOR READER: n = " << n << "\n";
+            foundSize = true;
+        } else {
+            int row, col;
+            _TYPE_ val;
+            lineData >> row >> col >> val;
+            (*b_values_h)[row - 1] =
+                val;  //-1 because mtx indexing is fortran like
+        }
+    }
+
+    file.close();
+}

--- a/cuDSS/simple_matrix_market/rhs.mtx
+++ b/cuDSS/simple_matrix_market/rhs.mtx
@@ -1,0 +1,8 @@
+%%MatrixMarket matrix coordinate real general
+% 5x5 matrix with 8 non-zero entries in coordinate format
+5 1 5
+1 1 7.0
+2 1 12.0
+3 1 25.0
+4 1 4.0
+5 1 13.0

--- a/cuDSS/simple_matrix_market/simple_matrix_market.cpp
+++ b/cuDSS/simple_matrix_market/simple_matrix_market.cpp
@@ -113,6 +113,7 @@ int main (int argc, char *argv[]) {
     if (argc < 2) 
     {
         fprintf(stderr, "Usage: %s <matrix_filename> <vector_filename (optional)> \n", argv[0]);
+        printf("use matrix.mtx and rhs.mtx for a reference execution\n")
         return EXIT_FAILURE;
     }
 

--- a/cuDSS/simple_matrix_market/simple_matrix_market.cpp
+++ b/cuDSS/simple_matrix_market/simple_matrix_market.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2023-2025 NVIDIA Corporation.  All rights reserved.
+ *
+ * NOTICE TO LICENSEE:
+ *
+ * This source code and/or documentation ("Licensed Deliverables") are
+ * subject to NVIDIA intellectual property rights under U.S. and
+ * international Copyright laws.
+ *
+ * These Licensed Deliverables contained herein is PROPRIETARY and
+ * CONFIDENTIAL to NVIDIA and is being provided under the terms and
+ * conditions of a form of NVIDIA software license agreement by and
+ * between NVIDIA and Licensee ("License Agreement") or electronically
+ * accepted by Licensee.  Notwithstanding any terms or conditions to
+ * the contrary in the License Agreement, reproduction or disclosure
+ * of the Licensed Deliverables to any third party without the express
+ * written consent of NVIDIA is prohibited.
+ *
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+ * LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
+ * SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
+ * PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF ANY KIND.
+ * NVIDIA DISCLAIMS ALL WARRANTIES WITH REGARD TO THESE LICENSED
+ * DELIVERABLES, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+ * LICENSE AGREEMENT, IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THESE LICENSED DELIVERABLES.
+ *
+ * U.S. Government End Users.  These Licensed Deliverables are a
+ * "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
+ * 1995), consisting of "commercial computer software" and "commercial
+ * computer software documentation" as such terms are used in 48
+ * C.F.R. 12.212 (SEPT 1995) and is provided to the U.S. Government
+ * only as a commercial end item.  Consistent with 48 C.F.R.12.212 and
+ * 48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
+ * U.S. Government End Users acquire the Licensed Deliverables with
+ * only those rights set forth herein.
+ *
+ * Any use of the Licensed Deliverables in individual and commercial
+ * software must include, in the user documentation and internal
+ * comments to the code, the above Disclaimer and U.S. Government End
+ * Users Notice.
+ */
+
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <math.h>
+ #include <assert.h>
+ #include <cuda_runtime.h>
+ 
+ #include "cudss.h"
+ #include "matrix_market_reader.h"
+ /*
+     This example demonstrates basic usage of cuDSS APIs for solving
+     a system of linear algebraic equations with a sparse matrix:
+                                 Ax = b,
+     where:
+         A is the sparse input matrix,
+         b is the (dense) right-hand side vector (or a matrix),
+         x is the (dense) solution vector (or a matrix).
+ */
+ 
+ #define CUDSS_EXAMPLE_FREE \
+ do { \
+     free(csr_offsets_h); \
+     free(csr_columns_h); \
+     free(csr_values_h); \
+     free(x_values_h); \
+     free(b_values_h); \
+     cudaFree(csr_offsets_d); \
+     cudaFree(csr_columns_d); \
+     cudaFree(csr_values_d); \
+     cudaFree(x_values_d); \
+     cudaFree(b_values_d); \
+ } while(0);
+
+#define CUDA_CALL_AND_CHECK(call, msg) \
+ do { \
+     cuda_error = call; \
+     if (cuda_error != cudaSuccess) { \
+         printf("Example FAILED: CUDA API returned error = %d, details: " #msg "\n", cuda_error); \
+         CUDSS_EXAMPLE_FREE; \
+         return -1; \
+     } \
+ } while(0);
+
+
+#define CUDSS_CALL_AND_CHECK(call, status, msg) \
+ do { \
+     status = call; \
+     if (status != CUDSS_STATUS_SUCCESS) { \
+         printf("Example FAILED: CUDSS call ended unsuccessfully with status = %d, details: " #msg "\n", status); \
+         CUDSS_EXAMPLE_FREE; \
+         return -2; \
+     } \
+ } while(0);
+
+
+int main (int argc, char *argv[]) {
+
+    cudaError_t cuda_error = cudaSuccess;
+    cudssStatus_t status = CUDSS_STATUS_SUCCESS;
+ 
+    int n;
+    int nnz ;
+    int nrhs = 1;
+
+    if (argc < 2) 
+    {
+        fprintf(stderr, "Usage: %s <matrix_filename> <vector_filename (optional)> \n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    const char* filename = argv[1];
+
+    int *csr_offsets_h = NULL;
+    int *csr_columns_h = NULL;
+    double *csr_values_h = NULL;
+    double *x_values_h = NULL, *b_values_h = NULL;
+
+    int *csr_offsets_d = NULL;
+    int *csr_columns_d = NULL;
+    double *csr_values_d = NULL;
+    double *x_values_d = NULL, *b_values_d = NULL;
+
+    /* Read input matrix from file and allocate host memory accordingly */
+    matrix_reader(filename, n, nnz, &csr_offsets_h, &csr_columns_h, &csr_values_h);
+
+    printf("---------------------------------------------------------\n");
+    printf("cuDSS example: solving a real linear %dx%d system from a file\n",n,n);
+    printf("---------------------------------------------------------\n");
+
+    /* Allocate host memory for solution x*/ 
+    x_values_h = (double*)malloc(nrhs * n * sizeof(double));
+
+    /* Allocate host memory for right hand side b and fill it*/ 
+    /* Read from file if rhs file is provided */
+    if (argc>2)
+    { 
+        const char* filename_vect = argv[2];
+        rhs_reader(filename_vect, n, &b_values_h);
+    }
+    else
+    {
+        std::cout<<"No rhs file provided, filling b with 1.0 \n";
+        b_values_h = (double*)malloc(nrhs * n * sizeof(double));
+        for (int i=0; i<n; i++){b_values_h[i] = 1.0;}
+    }
+    if (!csr_offsets_h || ! csr_columns_h || !csr_values_h ||
+        !x_values_h || !b_values_h) {
+        printf("Error: host memory allocation failed\n");
+        return -1;
+    }
+     
+    /* Allocate device memory for A, x and b */
+    CUDA_CALL_AND_CHECK(cudaMalloc(&csr_offsets_d, (n + 1) * sizeof(int)),
+                        "cudaMalloc for csr_offsets");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&csr_columns_d, nnz * sizeof(int)),
+                        "cudaMalloc for csr_columns");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&csr_values_d, nnz * sizeof(double)),
+                        "cudaMalloc for csr_values");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&b_values_d, nrhs * n * sizeof(double)),
+                        "cudaMalloc for b_values");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&x_values_d, nrhs * n * sizeof(double)),
+                        "cudaMalloc for x_values");
+
+    /* Copy host memory to device for A and b */
+    CUDA_CALL_AND_CHECK(cudaMemcpy(csr_offsets_d, csr_offsets_h, (n + 1) * sizeof(int),
+                        cudaMemcpyHostToDevice), "cudaMemcpy for csr_offsets");
+    CUDA_CALL_AND_CHECK(cudaMemcpy(csr_columns_d, csr_columns_h, nnz * sizeof(int),
+                        cudaMemcpyHostToDevice), "cudaMemcpy for csr_columns");
+    CUDA_CALL_AND_CHECK(cudaMemcpy(csr_values_d, csr_values_h, nnz * sizeof(double),
+                        cudaMemcpyHostToDevice), "cudaMemcpy for csr_values");
+    CUDA_CALL_AND_CHECK(cudaMemcpy(b_values_d, b_values_h, nrhs * n * sizeof(double),
+                        cudaMemcpyHostToDevice), "cudaMemcpy for b_values");
+
+    /* Create a CUDA stream */
+    cudaStream_t stream = NULL;
+    CUDA_CALL_AND_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    /* Creating the cuDSS library handle */
+    cudssHandle_t handle;
+
+    CUDSS_CALL_AND_CHECK(cudssCreate(&handle), status, "cudssCreate");
+
+    /* (optional) Setting the custom stream for the library handle */
+    CUDSS_CALL_AND_CHECK(cudssSetStream(handle, stream), status, "cudssSetStream");
+
+    /* Creating cuDSS solver configuration and data objects */
+    cudssConfig_t solverConfig;
+    cudssData_t solverData;
+
+    CUDSS_CALL_AND_CHECK(cudssConfigCreate(&solverConfig), status, "cudssConfigCreate");
+    CUDSS_CALL_AND_CHECK(cudssDataCreate(handle, &solverData), status, "cudssDataCreate");
+
+    /* Create matrix objects for the right-hand side b and solution x (as dense matrices). */
+    cudssMatrix_t x, b;
+
+    int64_t nrows = n, ncols = n;
+    int ldb = ncols, ldx = nrows;
+    CUDSS_CALL_AND_CHECK(cudssMatrixCreateDn(&b, ncols, nrhs, ldb, b_values_d, CUDA_R_64F,
+                         CUDSS_LAYOUT_COL_MAJOR), status, "cudssMatrixCreateDn for b");
+    CUDSS_CALL_AND_CHECK(cudssMatrixCreateDn(&x, nrows, nrhs, ldx, x_values_d, CUDA_R_64F,
+                         CUDSS_LAYOUT_COL_MAJOR), status, "cudssMatrixCreateDn for x");
+
+    /* Create a matrix object for the sparse input matrix. */
+    cudssMatrix_t A;
+    cudssMatrixType_t mtype     = CUDSS_MTYPE_SPD;
+    cudssMatrixViewType_t mview = CUDSS_MVIEW_UPPER;
+    cudssIndexBase_t base       = CUDSS_BASE_ZERO;
+    CUDSS_CALL_AND_CHECK(cudssMatrixCreateCsr(&A, nrows, ncols, nnz, csr_offsets_d, NULL,
+                         csr_columns_d, csr_values_d, CUDA_R_32I, CUDA_R_64F, mtype, mview,
+                         base), status, "cudssMatrixCreateCsr");
+
+    /* Symbolic factorization */
+    CUDSS_CALL_AND_CHECK(cudssExecute(handle, CUDSS_PHASE_ANALYSIS, solverConfig, solverData,
+                         A, x, b), status, "cudssExecute for analysis");
+
+    /* Factorization */
+    CUDSS_CALL_AND_CHECK(cudssExecute(handle, CUDSS_PHASE_FACTORIZATION, solverConfig,
+                         solverData, A, x, b), status, "cudssExecute for factor");
+
+    /* Solving */
+    CUDSS_CALL_AND_CHECK(cudssExecute(handle, CUDSS_PHASE_SOLVE, solverConfig, solverData,
+                         A, x, b), status, "cudssExecute for solve");
+
+    /* Destroying opaque objects, matrix wrappers and the cuDSS library handle */
+    CUDSS_CALL_AND_CHECK(cudssMatrixDestroy(A), status, "cudssMatrixDestroy for A");
+    CUDSS_CALL_AND_CHECK(cudssMatrixDestroy(b), status, "cudssMatrixDestroy for b");
+    CUDSS_CALL_AND_CHECK(cudssMatrixDestroy(x), status, "cudssMatrixDestroy for x");
+    CUDSS_CALL_AND_CHECK(cudssDataDestroy(handle, solverData), status, "cudssDataDestroy");
+    CUDSS_CALL_AND_CHECK(cudssConfigDestroy(solverConfig), status, "cudssConfigDestroy");
+    CUDSS_CALL_AND_CHECK(cudssDestroy(handle), status, "cudssHandleDestroy");
+
+    CUDA_CALL_AND_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+    /* Print the solution and compare against the exact solution */
+    CUDA_CALL_AND_CHECK(cudaMemcpy(x_values_h, x_values_d, nrhs * n * sizeof(double),
+                        cudaMemcpyDeviceToHost), "cudaMemcpy for x_values");
+
+    int passed = 1;
+    for (int i = 0; i < n; i++) {
+        printf("x[%d] = %1.4f expected %1.4f\n", i, x_values_h[i], double(i+1));
+        if (fabs(x_values_h[i] - (i + 1)) > 2.e-15)
+          passed = 0;
+    }
+
+    /* Release the data allocated on the user side */
+
+    CUDSS_EXAMPLE_FREE;
+    
+    if (status == CUDSS_STATUS_SUCCESS && passed) {
+        printf("Example PASSED\n");
+        return 0;
+    } else {
+        printf("Example FAILED (note, this is normal if you did not use the provided 5x5 matrix and rhs file)\n");
+        return -1;
+    }
+}


### PR DESCRIPTION
This MR adds a sample code for reading an input matrix market file for a simple cuDSS resolution. If the user gives the provided matrices, it will be the exact same resolution as the one in the original "simple" example.

Let me know if this is useless (is there a reader somewhere else ?). If useful, let me know what I can do to improve if necessary.