### PR TITLE
Fix "-lcuhash-o" error in cuPQC examples' Makefile

### DIFF
--- a/cuPQC/Makefile
+++ b/cuPQC/Makefile
@@ -14,7 +14,7 @@ SRCS = $(wildcard *.cu)
 TARGETS=$(patsubst %.cu,%,$(SRCS))
 
 $(TARGETS): %: %.cu
-	$(NVCC) $(NVCC_FLAGS) -L$(CUPQC_DIR)/lib/ -lcupqc -lcuhash-o $@ $<  -I$(COMMONDX_INCLUDE_DIR) -I$(CUPQC_INCLUDE_DIR) 
+	$(NVCC) $(NVCC_FLAGS) -L$(CUPQC_DIR)/lib/ -lcupqc -lcuhash -o $@ $<  -I$(COMMONDX_INCLUDE_DIR) -I$(CUPQC_INCLUDE_DIR) 
 .PHONY: all clean
 
 all: $(TARGETS) 


### PR DESCRIPTION
This is a typographical error in cuPQC examples. 

Makefile would not "make" without this fix.

"-lcuhash-o" --> "-lcuhash -o"