### PR TITLE
[cuDSS] Add a sample code for reading an input matrix market file for a simple cuDSS resolution

### DIFF
--- a/cuDSS/README.md
+++ b/cuDSS/README.md
@@ -15,6 +15,10 @@ For further details, please check the release notes in the official documentatio
 
     The sample demonstrates how to use cuDSS for solving a real sparse linear system without any advanced features
 
+* [Simple workflow for solving a real-valued sparse linear system from a matrix market file](simple_matrix_market/)
+
+    The sample demonstrates how to use cuDSS for solving a real sparse linear system read from a `.mtx` file without any advanced features
+
 * [Simple workflow for solving a complex-valued sparse linear system](simple_complex/)
 
     The sample demonstrates how to use cuDSS for solving a complex sparse linear system without any advanced features

--- a/cuDSS/simple_matrix_market/CMakeLists.txt
+++ b/cuDSS/simple_matrix_market/CMakeLists.txt
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Rémi Bourgeois. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.19)
+
+set(EXAMPLE_NAME simple_matrix_market)
+
+project("cuDSS_${EXAMPLE_NAME}_example"
+        DESCRIPTION  "cuDSS"
+        HOMEPAGE_URL "https://docs.nvidia.com/cuda/cudss/index.html"
+        LANGUAGES    CXX CUDA)
+
+set(CMAKE_CUDA_STANDARD          17)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_EXTENSIONS        OFF)
+
+option(BUILD_STATIC "Building statically linked examples" OFF)
+
+# Find cuDSS
+find_package(cudss 0.6.0 REQUIRED)
+
+set_source_files_properties(${EXAMPLE_NAME}.cpp PROPERTIES LANGUAGE CUDA)
+
+add_executable(${EXAMPLE_NAME}_example)
+
+target_sources(${EXAMPLE_NAME}_example
+    PUBLIC ${PROJECT_SOURCE_DIR}/${EXAMPLE_NAME}.cpp
+)
+
+if (WIN32)
+    target_include_directories(${EXAMPLE_NAME}_example PUBLIC ${cudss_INCLUDE_DIR})
+    target_link_directories(${EXAMPLE_NAME}_example PUBLIC ${cudss_LIBRARY_DIR})
+endif()
+
+target_compile_options(${EXAMPLE_NAME}_example PRIVATE
+    "$<$<CONFIG:Debug>:-lineinfo -g>"
+    "$<$<CONFIG:RelWithDebInfo>:-lineinfo -g>"
+)
+
+target_link_libraries(${EXAMPLE_NAME}_example PUBLIC
+    cudss
+)
+
+if(BUILD_STATIC)
+    add_executable(${EXAMPLE_NAME}_example_static)
+
+    target_sources(${EXAMPLE_NAME}_example_static
+        PUBLIC ${PROJECT_SOURCE_DIR}/${EXAMPLE_NAME}.cpp
+    )
+
+    if (WIN32)
+        target_include_directories(${EXAMPLE_NAME}_example_static PUBLIC ${cudss_INCLUDE_DIR})
+        target_link_directories(${EXAMPLE_NAME}_example_static PUBLIC ${cudss_LIBRARY_DIR})
+        target_link_libraries(${EXAMPLE_NAME}_example_static PUBLIC
+        cudss
+    )
+    else()
+        target_link_libraries(${EXAMPLE_NAME}_example_static PUBLIC
+            cudss_static
+        )
+    endif()
+
+endif()

--- a/cuDSS/simple_matrix_market/matrix.mtx
+++ b/cuDSS/simple_matrix_market/matrix.mtx
@@ -1,0 +1,11 @@
+%%MatrixMarket matrix coordinate real general
+% 5x5 matrix with 8 non-zero entries in coordinate format
+5 5 8
+1 1 4.0
+1 3 1.0
+2 2 3.0
+2 3 2.0
+3 3 5.0
+3 5 1.0
+4 4 1.0
+5 5 2.0

--- a/cuDSS/simple_matrix_market/matrix.mtx
+++ b/cuDSS/simple_matrix_market/matrix.mtx
@@ -1,4 +1,4 @@
-%%MatrixMarket matrix coordinate real general
+%%MatrixMarket matrix coordinate real spd
 % 5x5 matrix with 8 non-zero entries in coordinate format
 5 5 8
 1 1 4.0

--- a/cuDSS/simple_matrix_market/matrix_market_reader.h
+++ b/cuDSS/simple_matrix_market/matrix_market_reader.h
@@ -1,24 +1,24 @@
-/* 
-SPDX-FileCopyrightText: Copyright (c) 2025 Rémi Bourgeois. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Rémi Bourgeois. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <algorithm>
 #include <tuple>
 
 enum MtxReaderStatus {
@@ -34,80 +34,87 @@ enum MtxReaderStatus {
 };
 
 template <typename value_type>
-int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
-                  int** csr_columns_h, value_type** csr_values_h, cudssMatrixViewType_t mview)
-{
+int matrix_reader(std::string filename, int &n, int &nnz, int **csr_offsets_h,
+                  int **csr_columns_h, value_type **csr_values_h,
+                  cudssMatrixViewType_t mview) {
     std::ifstream file(filename);
     if (!file.is_open()) {
         fprintf(stderr, "Error: Could not open file %s\n", filename.c_str());
         *csr_offsets_h = NULL;
         *csr_columns_h = NULL;
-        *csr_values_h = NULL;
-        return  MtxReaderErrorFileNotFound;
+        *csr_values_h  = NULL;
+        return MtxReaderErrorFileNotFound;
     }
 
     std::string line;
-    bool foundSize = false;
-    int declared_nnz = 0;
-    int file_line_count = 0;
-    int foundHeader = false;
+    bool        foundSize       = false;
+    int         declared_nnz    = 0;
+    int         file_line_count = 0;
+    int         foundHeader     = false;
 
-    //Tuple for the mtw lines
+    // Tuple for the mtw lines
     std::vector<std::tuple<int, int, value_type>> entries;
 
     bool FoundAlowerElement = false, FoundAUpperElement = false;
 
     while (std::getline(file, line)) {
-        
-        //Get line
+
+        // Get line
         std::istringstream lineData(line);
-        
-        //skip empty lines
-        if (line.empty()) 
+
+        // skip empty lines
+        if (line.empty())
             continue;
 
-        //skip comments
-        if (foundHeader && line[0]=='%') 
+        // skip comments
+        if (foundHeader && line[0] == '%')
             continue;
 
-        //Get header
-        if (!foundHeader && line.substr(0, 14) == "%%MatrixMarket"){
+        // Get header
+        if (!foundHeader && line.substr(0, 14) == "%%MatrixMarket") {
             foundHeader = true;
-                
+
             // Parse header: %%MatrixMarket matrix coordinate real general
             std::string marker, object, format, value_type_header, symmetry;
-            
+
             lineData >> marker >> object >> format >> value_type_header >> symmetry;
-            
+
             // Check if it's matrix coordinate real
-            if (object != "matrix" || format != "coordinate" || value_type_header != "real") {
-                fprintf(stderr, "ERROR: Expected 'matrix coordinate real for the matrix file header\n");
-                fprintf(stderr, "Got: object=%s format=%s value_type=%s\n", 
+            if (object != "matrix" || format != "coordinate" ||
+                value_type_header != "real") {
+                fprintf(stderr, "ERROR: Expected 'matrix coordinate real for the matrix "
+                                "file header\n");
+                fprintf(stderr, "Got: object=%s format=%s value_type=%s\n",
                         object.c_str(), format.c_str(), value_type_header.c_str());
-                    return MtxReaderErrorInvalidFormatInHeader;
+                return MtxReaderErrorInvalidFormatInHeader;
             }
             continue;
         }
 
-        //Get sizes
+        // Get sizes
         if (!foundSize) {
             int n1;
             lineData >> n >> n1 >> declared_nnz;
             printf("MATRIX READER: n0= %d, n1= %d, nnz= %d\n", n, n1, declared_nnz);
             foundSize = true;
-        //Get line
-        } else {
-            int i, j;
+        }
+        // Get line
+        else {
+            int        i, j;
             value_type val;
             lineData >> i >> j >> val;
-            i -= 1; j -= 1;  // Convert from 1-based to 0-based
+            // Convert from 1-based to 0-based
+            i -= 1;
+            j -= 1;
 
-            //Append the tuple to entries (resize everytime so sub-optimal)
+            // Append the tuple to entries (resize everytime so sub-optimal)
             entries.emplace_back(i, j, val);
 
-            if (i > j) FoundAlowerElement = true;
-            if (i < j) FoundAUpperElement = true;
-            file_line_count+=1;
+            if (i > j)
+                FoundAlowerElement = true;
+            if (i < j)
+                FoundAUpperElement = true;
+            file_line_count += 1;
         }
     }
 
@@ -115,9 +122,9 @@ int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
     nnz = entries.size();
 
     // Allocate memory
-    *csr_offsets_h = (int*)malloc((n + 1) * sizeof(int));
-    *csr_columns_h = (int*)malloc(nnz * sizeof(int));
-    *csr_values_h = (value_type*)malloc(nnz * sizeof(value_type));
+    *csr_offsets_h = (int *)malloc((n + 1) * sizeof(int));
+    *csr_columns_h = (int *)malloc(nnz * sizeof(int));
+    *csr_values_h  = (value_type *)malloc(nnz * sizeof(value_type));
 
     if (!(*csr_offsets_h) || !(*csr_columns_h) || !(*csr_values_h)) {
         fprintf(stderr, "ERROR: Memory allocation failed\n");
@@ -125,7 +132,8 @@ int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
     }
 
     if (file_line_count != declared_nnz) {
-        fprintf(stderr, "ERROR: more elements in the mtx file than announced in the header\n");
+        fprintf(stderr,
+                "ERROR: more elements in the mtx file than announced in the header\n");
         return MtxReaderErrorWrongNnz;
     }
 
@@ -142,15 +150,16 @@ int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
     }
 
     if (!(FoundAUpperElement && FoundAlowerElement) && mview == CUDSS_MVIEW_FULL) {
-        fprintf(stdout, "WARNING: mview is full, but only lower or upper elements found\n");
+        fprintf(stdout,
+                "WARNING: mview is full, but only lower or upper elements found\n");
     }
 
-    //Initialize with 0's
+    // Initialize with 0's
     std::fill(*csr_offsets_h, *csr_offsets_h + (n + 1), 0);
 
     int current_idx = 0;
 
-    for (auto& [i, j, val] : entries) {
+    for (auto &[i, j, val] : entries) {
         if (i >= n || i < 0) {
             fprintf(stderr, "ERROR: Invalid row index %d\n", i);
             return MtxReaderErrorOutOfBoundRowIndex;
@@ -161,14 +170,14 @@ int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
         }
         (*csr_offsets_h)[i + 1]++;
         (*csr_columns_h)[current_idx] = j;
-        (*csr_values_h)[current_idx] = val;
+        (*csr_values_h)[current_idx]  = val;
         current_idx++;
     }
 
     // Prefix sum to compute the offsets
-    for (int i = 0; i < n; ++i) 
+    for (int i = 0; i < n; ++i)
         (*csr_offsets_h)[i + 1] += (*csr_offsets_h)[i];
-        
+
 
     // Detect empty rows
     for (int i = 0; i < n; ++i) {
@@ -182,7 +191,7 @@ int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
 }
 
 template <typename value_type>
-int rhs_reader(std::string filename, int& n, value_type** b_values_h) {
+int rhs_reader(std::string filename, int &n, value_type **b_values_h) {
     std::ifstream file(filename);
 
     if (!file.is_open()) {
@@ -191,36 +200,37 @@ int rhs_reader(std::string filename, int& n, value_type** b_values_h) {
     }
 
     std::string line;
-    bool foundSize = false;
-    bool foundHeader = false;
-    int row = 0;
+    bool        foundSize   = false;
+    bool        foundHeader = false;
+    int         row         = 0;
     while (std::getline(file, line)) {
-        //Get line
+        // Get line
         std::istringstream lineData(line);
-        
-        //skip empty lines
-        if (line.empty()) 
+
+        // skip empty lines
+        if (line.empty())
             continue;
 
-        //skip comments
-        if (foundHeader && line[0]=='%') 
+        // skip comments
+        if (foundHeader && line[0] == '%')
             continue;
 
-        //Get header
-        if (!foundHeader && line.substr(0, 14) == "%%MatrixMarket"){
+        // Get header
+        if (!foundHeader && line.substr(0, 14) == "%%MatrixMarket") {
             foundHeader = true;
-                
+
             // Parse header: %%MatrixMarket matrix coordinate real general
             std::string marker, object, format, value_type_header, symmetry;
-            
+
             lineData >> marker >> object >> format >> value_type_header >> symmetry;
-            
+
             // Check if it's matrix coordinate real
             if (object != "matrix" || format != "array" || value_type_header != "real") {
-                fprintf(stderr, "ERROR: Expected 'matrix array real for the rhs file header\n");
-                fprintf(stderr, "Got: object=%s format=%s value_type=%s\n", 
+                fprintf(stderr,
+                        "ERROR: Expected 'matrix array real for the rhs file header\n");
+                fprintf(stderr, "Got: object=%s format=%s value_type=%s\n",
                         object.c_str(), format.c_str(), value_type_header.c_str());
-                    return MtxReaderErrorInvalidFormatInHeader;
+                return MtxReaderErrorInvalidFormatInHeader;
             }
             continue;
         }
@@ -232,15 +242,15 @@ int rhs_reader(std::string filename, int& n, value_type** b_values_h) {
                 fprintf(stderr, "Only one RHS is supported, %d found\n.", num_rhs);
                 return EXIT_FAILURE;
             }
-            *b_values_h = (value_type*)malloc(n * sizeof(value_type));
+            *b_values_h = (value_type *)malloc(n * sizeof(value_type));
             printf("RHS READER: allocated host memory\n");
             printf("RHS READER: n = %d\n", n);
             foundSize = true;
         } else {
             value_type val;
             lineData >> val;
-            (*b_values_h)[row] = val;  
-            row += 1;
+            (*b_values_h)[row]  = val;
+            row                += 1;
         }
     }
 

--- a/cuDSS/simple_matrix_market/matrix_market_reader.h
+++ b/cuDSS/simple_matrix_market/matrix_market_reader.h
@@ -1,0 +1,249 @@
+/* 
+SPDX-FileCopyrightText: Copyright (c) 2025 Rémi Bourgeois. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <tuple>
+
+enum MtxReaderStatus {
+    MtxReaderSuccess,
+    MtxReaderErrorFileNotFound,
+    MtxReaderErrorFileMemAllocFailed,
+    MtxReaderErrorWrongNnz,
+    MtxReaderErrorUpperViewButLowerFound,
+    MtxReaderErrorLowerViewButUpperFound,
+    MtxReaderErrorOutOfBoundRowIndex,
+    MtxReaderErrorOfBoundColIndex,
+    MtxReaderErrorInvalidFormatInHeader
+};
+
+template <typename value_type>
+int matrix_reader(std::string filename, int& n, int& nnz, int** csr_offsets_h,
+                  int** csr_columns_h, value_type** csr_values_h, cudssMatrixViewType_t mview)
+{
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        fprintf(stderr, "Error: Could not open file %s\n", filename.c_str());
+        *csr_offsets_h = NULL;
+        *csr_columns_h = NULL;
+        *csr_values_h = NULL;
+        return  MtxReaderErrorFileNotFound;
+    }
+
+    std::string line;
+    bool foundSize = false;
+    int declared_nnz = 0;
+    int file_line_count = 0;
+    int foundHeader = false;
+
+    //Tuple for the mtw lines
+    std::vector<std::tuple<int, int, value_type>> entries;
+
+    bool FoundAlowerElement = false, FoundAUpperElement = false;
+
+    while (std::getline(file, line)) {
+        
+        //Get line
+        std::istringstream lineData(line);
+        
+        //skip empty lines
+        if (line.empty()) 
+            continue;
+
+        //skip comments
+        if (foundHeader && line[0]=='%') 
+            continue;
+
+        //Get header
+        if (!foundHeader && line.substr(0, 14) == "%%MatrixMarket"){
+            foundHeader = true;
+                
+            // Parse header: %%MatrixMarket matrix coordinate real general
+            std::string marker, object, format, value_type_header, symmetry;
+            
+            lineData >> marker >> object >> format >> value_type_header >> symmetry;
+            
+            // Check if it's matrix coordinate real
+            if (object != "matrix" || format != "coordinate" || value_type_header != "real") {
+                fprintf(stderr, "ERROR: Expected 'matrix coordinate real for the matrix file header\n");
+                fprintf(stderr, "Got: object=%s format=%s value_type=%s\n", 
+                        object.c_str(), format.c_str(), value_type_header.c_str());
+                    return MtxReaderErrorInvalidFormatInHeader;
+            }
+            continue;
+        }
+
+        //Get sizes
+        if (!foundSize) {
+            int n1;
+            lineData >> n >> n1 >> declared_nnz;
+            printf("MATRIX READER: n0= %d, n1= %d, nnz= %d\n", n, n1, declared_nnz);
+            foundSize = true;
+        //Get line
+        } else {
+            int i, j;
+            value_type val;
+            lineData >> i >> j >> val;
+            i -= 1; j -= 1;  // Convert from 1-based to 0-based
+
+            //Append the tuple to entries (resize everytime so sub-optimal)
+            entries.emplace_back(i, j, val);
+
+            if (i > j) FoundAlowerElement = true;
+            if (i < j) FoundAUpperElement = true;
+            file_line_count+=1;
+        }
+    }
+
+    file.close();
+    nnz = entries.size();
+
+    // Allocate memory
+    *csr_offsets_h = (int*)malloc((n + 1) * sizeof(int));
+    *csr_columns_h = (int*)malloc(nnz * sizeof(int));
+    *csr_values_h = (value_type*)malloc(nnz * sizeof(value_type));
+
+    if (!(*csr_offsets_h) || !(*csr_columns_h) || !(*csr_values_h)) {
+        fprintf(stderr, "ERROR: Memory allocation failed\n");
+        return MtxReaderErrorFileMemAllocFailed;
+    }
+
+    if (file_line_count != declared_nnz) {
+        fprintf(stderr, "ERROR: more elements in the mtx file than announced in the header\n");
+        return MtxReaderErrorWrongNnz;
+    }
+
+    std::sort(entries.begin(), entries.end());
+
+    if ((FoundAlowerElement) && (mview == CUDSS_MVIEW_UPPER)) {
+        fprintf(stderr, "ERROR: mview is upper, but lower elements found\n");
+        return MtxReaderErrorUpperViewButLowerFound;
+    }
+
+    if ((FoundAUpperElement) && (mview == CUDSS_MVIEW_LOWER)) {
+        fprintf(stderr, "ERROR: mview is lower, but upper elements found\n");
+        return MtxReaderErrorLowerViewButUpperFound;
+    }
+
+    if (!(FoundAUpperElement && FoundAlowerElement) && mview == CUDSS_MVIEW_FULL) {
+        fprintf(stdout, "WARNING: mview is full, but only lower or upper elements found\n");
+    }
+
+    //Initialize with 0's
+    std::fill(*csr_offsets_h, *csr_offsets_h + (n + 1), 0);
+
+    int current_idx = 0;
+
+    for (auto& [i, j, val] : entries) {
+        if (i >= n || i < 0) {
+            fprintf(stderr, "ERROR: Invalid row index %d\n", i);
+            return MtxReaderErrorOutOfBoundRowIndex;
+        }
+        if (j >= n || j < 0) {
+            fprintf(stderr, "ERROR: Invalid col index %d\n", j);
+            return MtxReaderErrorOfBoundColIndex;
+        }
+        (*csr_offsets_h)[i + 1]++;
+        (*csr_columns_h)[current_idx] = j;
+        (*csr_values_h)[current_idx] = val;
+        current_idx++;
+    }
+
+    // Prefix sum to compute the offsets
+    for (int i = 0; i < n; ++i) 
+        (*csr_offsets_h)[i + 1] += (*csr_offsets_h)[i];
+        
+
+    // Detect empty rows
+    for (int i = 0; i < n; ++i) {
+        if ((*csr_offsets_h)[i] == (*csr_offsets_h)[i + 1]) {
+            printf("Warning: Row %d is empty\n", i);
+        }
+    }
+
+    printf("MATRIX READER: Completed with %d nonzeros\n", nnz);
+    return 0;
+}
+
+template <typename value_type>
+int rhs_reader(std::string filename, int& n, value_type** b_values_h) {
+    std::ifstream file(filename);
+
+    if (!file.is_open()) {
+        fprintf(stderr, "Error: Could not open file %s\n", filename.c_str());
+        return EXIT_FAILURE;
+    }
+
+    std::string line;
+    bool foundSize = false;
+    bool foundHeader = false;
+    int row = 0;
+    while (std::getline(file, line)) {
+        //Get line
+        std::istringstream lineData(line);
+        
+        //skip empty lines
+        if (line.empty()) 
+            continue;
+
+        //skip comments
+        if (foundHeader && line[0]=='%') 
+            continue;
+
+        //Get header
+        if (!foundHeader && line.substr(0, 14) == "%%MatrixMarket"){
+            foundHeader = true;
+                
+            // Parse header: %%MatrixMarket matrix coordinate real general
+            std::string marker, object, format, value_type_header, symmetry;
+            
+            lineData >> marker >> object >> format >> value_type_header >> symmetry;
+            
+            // Check if it's matrix coordinate real
+            if (object != "matrix" || format != "array" || value_type_header != "real") {
+                fprintf(stderr, "ERROR: Expected 'matrix array real for the rhs file header\n");
+                fprintf(stderr, "Got: object=%s format=%s value_type=%s\n", 
+                        object.c_str(), format.c_str(), value_type_header.c_str());
+                    return MtxReaderErrorInvalidFormatInHeader;
+            }
+            continue;
+        }
+
+        if (!foundSize) {
+            int num_rhs;
+            lineData >> n >> num_rhs;
+            if (num_rhs != 1) {
+                fprintf(stderr, "Only one RHS is supported, %d found\n.", num_rhs);
+                return EXIT_FAILURE;
+            }
+            *b_values_h = (value_type*)malloc(n * sizeof(value_type));
+            printf("RHS READER: allocated host memory\n");
+            printf("RHS READER: n = %d\n", n);
+            foundSize = true;
+        } else {
+            value_type val;
+            lineData >> val;
+            (*b_values_h)[row] = val;  
+            row += 1;
+        }
+    }
+
+    file.close();
+    return 0;
+}

--- a/cuDSS/simple_matrix_market/rhs.mtx
+++ b/cuDSS/simple_matrix_market/rhs.mtx
@@ -1,0 +1,8 @@
+%%MatrixMarket matrix array real general
+% 5x1 vector
+5 1
+7.0
+12.0
+25.0
+4.0
+13.0

--- a/cuDSS/simple_matrix_market/simple_matrix_market.cpp
+++ b/cuDSS/simple_matrix_market/simple_matrix_market.cpp
@@ -1,0 +1,432 @@
+/* 
+SPDX-FileCopyrightText: Copyright (c) 2025 Rémi Bourgeois. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <assert.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <iostream>
+#include <vector>
+
+#include "cudss.h"
+#include "matrix_market_reader.h"
+
+/*
+    This example demonstrates basic usage of cuDSS APIs for solving
+    a system of linear algebraic equations with a sparse matrix
+    coming from a matrix market file:
+           Ax = b,
+    where:
+        A is the sparse input matrix,
+        b is the (dense) right-hand side vector (or a matrix),
+        x is the (dense) solution vector (or a matrix).
+
+    Example usage from build directory
+    ./simple_matrix_market_example 0 general full ../matrix.mtx ../rhs.mtx 
+*/
+
+double compute_residual_error(
+    int n,
+    const int* csr_offsets_h,
+    const int* csr_columns_h,
+    const double* csr_values_h,
+    const double* x_values_h,
+    const double* b_values_h,
+    cudssMatrixViewType_t mview)
+{
+    std::vector<double> Ax(n, 0.0);
+
+    for (int row = 0; row < n; ++row)
+    {
+        for (int idx = csr_offsets_h[row]; idx < csr_offsets_h[row + 1]; ++idx)
+        {
+            int col = csr_columns_h[idx];
+            double val = csr_values_h[idx];
+
+            switch (mview)
+            {
+                case CUDSS_MVIEW_FULL:
+                    Ax[row] += val * x_values_h[col];
+                    break;
+
+                case CUDSS_MVIEW_UPPER:
+                    if (col >= row) {
+                        Ax[row] += val * x_values_h[col];
+                        if (col != row) Ax[col] += val * x_values_h[row];
+                    }
+                    break;
+
+                case CUDSS_MVIEW_LOWER:
+                    if (col <= row) {
+                        Ax[row] += val * x_values_h[col];
+                        if (col != row) Ax[col] += val * x_values_h[row];
+                    }
+                    break;
+            }
+        }
+    }
+
+    // Compute L2 norm of residual
+    double error = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+        double diff = Ax[i] - b_values_h[i];
+        error += diff * diff;
+    }
+
+    return std::sqrt(error);
+}
+
+#define CUDSS_EXAMPLE_FREE       \
+    do                           \
+    {                            \
+        if (csr_offsets_h) free(csr_offsets_h);     \
+        if (csr_columns_h) free(csr_columns_h);     \
+        if (csr_values_h)  free(csr_values_h);      \
+        free(x_values_h);        \
+        free(b_values_h);        \
+        cudaFree(csr_offsets_d); \
+        cudaFree(csr_columns_d); \
+        cudaFree(csr_values_d);  \
+        cudaFree(x_values_d);    \
+        cudaFree(b_values_d);    \
+    } while (0);
+
+#define CUDA_CALL_AND_CHECK(call, msg)                                                               \
+    do                                                                                               \
+    {                                                                                                \
+        cuda_error = call;                                                                           \
+        if (cuda_error != cudaSuccess)                                                               \
+        {                                                                                            \
+            printf("Example FAILED: CUDA API returned error = %d, details: " #msg "\n", cuda_error); \
+            CUDSS_EXAMPLE_FREE;                                                                      \
+            return -1;                                                                               \
+        }                                                                                            \
+    } while (0);
+
+#define CUDSS_CALL_AND_CHECK(call, status, msg)                                                                      \
+    do                                                                                                               \
+    {                                                                                                                \
+        status = call;                                                                                               \
+        if (status != CUDSS_STATUS_SUCCESS)                                                                          \
+        {                                                                                                            \
+            printf("Example FAILED: CUDSS call ended unsuccessfully with status = %d, details: " #msg "\n", status); \
+            CUDSS_EXAMPLE_FREE;                                                                                      \
+            return -2;                                                                                               \
+        }                                                                                                            \
+    } while (0);
+
+int main(int argc, char *argv[])
+{
+
+    cudaError_t cuda_error = cudaSuccess;
+    cudssStatus_t status = CUDSS_STATUS_SUCCESS;
+
+    /*timers*/
+    cudaEvent_t start, stop;
+    float time_ms = 0.0f, total_ms = 0.0f;
+    // Create CUDA events
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    int n;
+    int nnz;
+    int nrhs = 1;
+
+    if (argc < 5)
+    {
+        fprintf(stderr,
+        "Usage: %s <alg: 0|1|2|3> <mtype: general|symmetric|hermitian|spd|hpd> "
+        "<mview: full|lower|upper> <matrix_filename> [vector_filename (optional)]\n",
+        argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    // Parse algorithm
+    int alg_input = std::atoi(argv[1]);
+    cudssAlgType_t reorder_alg;
+    switch (alg_input)
+    {
+    case 0:
+        reorder_alg = CUDSS_ALG_DEFAULT;
+        break;
+    case 1:
+        reorder_alg = CUDSS_ALG_1;
+        break;
+    case 2:
+        reorder_alg = CUDSS_ALG_2;
+        break;
+    case 3:
+        reorder_alg = CUDSS_ALG_3;
+        break;
+    default:
+        fprintf(stderr, "Error: Invalid algorithm '%s' (must be 0-3)\n", argv[1]);
+        return EXIT_FAILURE;
+    }
+
+    // Parse matrix type
+    cudssMatrixType_t mtype;
+    if (strcmp(argv[2], "general") == 0)
+        mtype = CUDSS_MTYPE_GENERAL;
+    else if (strcmp(argv[2], "symmetric") == 0)
+        mtype = CUDSS_MTYPE_SYMMETRIC;
+    else if (strcmp(argv[2], "hermitian") == 0)
+        mtype = CUDSS_MTYPE_HERMITIAN;
+    else if (strcmp(argv[2], "spd") == 0)
+        mtype = CUDSS_MTYPE_SPD;
+    else if (strcmp(argv[2], "hpd") == 0)
+        mtype = CUDSS_MTYPE_HPD;
+    else
+    {
+        fprintf(stderr, "Error: Invalid matrix type '%s'. Supported types are general, symmetric, hermitian, spd, hpd\n", argv[2]);
+        return EXIT_FAILURE;
+    }
+
+    if(((reorder_alg==1)||(reorder_alg==2)) && (mtype!=CUDSS_MTYPE_GENERAL)){
+        fprintf(stderr,
+        "Warining: Invalid algorithm. CUDSS_ALG_1 and CUDSS_ALG_2 are only supported for general (non-symmetric or non-hermitian) matrices.\n"
+        "See https://docs.nvidia.com/cuda/cudss/types.html#cudssconfigparam-t\n"
+        "Expect a large error.\n");
+    }
+
+    // Parse matrix view
+    cudssMatrixViewType_t mview;
+    if (strcmp(argv[3], "full") == 0)
+        mview = CUDSS_MVIEW_FULL;
+    else if (strcmp(argv[3], "lower") == 0)
+        mview = CUDSS_MVIEW_LOWER;
+    else if (strcmp(argv[3], "upper") == 0)
+        mview = CUDSS_MVIEW_UPPER;
+    else
+    {
+        fprintf(stderr,
+        "Error: Invalid matrix view type '%s'. Supported types are: full, lower, upper.\n",
+        argv[3]);    
+        return EXIT_FAILURE;
+    }
+
+    if ((mview != CUDSS_MVIEW_FULL)&&(mtype==CUDSS_MTYPE_GENERAL)){
+        fprintf(stderr,
+        "Error: you chose a lower/upper view of the matrix but you also specified that it is general (not symmetric).\n"
+        "If your matrix file is truly non-symmetric, half of the elements would not be used, as the lower/upper part of the\n"
+        "matrix will be mirrored and you will be solving for the wrong matrix. Or the reader will throw an error.\n");
+        return EXIT_FAILURE;
+    }
+
+    // Matrix and optional vector filenames
+    const char *matrix_filename = argv[4];
+    const char *vector_filename = (argc > 5) ? argv[5] : nullptr;
+
+    int *csr_offsets_h = NULL;
+    int *csr_columns_h = NULL;
+    double *csr_values_h = NULL;
+    double *x_values_h = NULL, *b_values_h = NULL;
+
+    int *csr_offsets_d = NULL;
+    int *csr_columns_d = NULL;
+    double *csr_values_d = NULL;
+    double *x_values_d = NULL, *b_values_d = NULL;
+
+    /* Read input matrix from file and allocate host memory accordingly */
+    int failed = matrix_reader(matrix_filename, n, nnz, &csr_offsets_h, &csr_columns_h, &csr_values_h, mview);
+    if (failed){
+        fprintf(stderr, "Reader failed.\n");
+        return EXIT_FAILURE;
+    }
+
+    printf("---------------------------------------------------------\n");
+    printf("cuDSS example: solving a real linear %dx%d system from file \"%s\"\n", n, n, matrix_filename);
+    printf("---------------------------------------------------------\n");
+
+    /* Allocate host memory for solution x*/
+    x_values_h = (double *)malloc(nrhs * n * sizeof(double));
+
+    /* Allocate host memory for right hand side b and fill it*/
+    /* Read from file if rhs file is provided */
+    if (vector_filename != nullptr)
+    {
+        int failed = rhs_reader(vector_filename, n, &b_values_h);
+        if (failed){
+            fprintf(stderr, "Reader failed.\n");     
+            return EXIT_FAILURE;
+        }
+    }
+    else
+    {
+        printf("No rhs file provided, filling b with 1.0");
+        b_values_h = (double *)malloc(nrhs * n * sizeof(double));
+        for (int i = 0; i < n; i++)
+        {
+            b_values_h[i] = 1.0;
+        }
+    }
+    if (!csr_offsets_h || !csr_columns_h || !csr_values_h ||
+        !x_values_h || !b_values_h)
+    {
+        fprintf(stderr, "Error: host memory allocation failed\n");
+        return -1;
+    }
+
+    /* Allocate device memory for A, x and b */
+    CUDA_CALL_AND_CHECK(cudaMalloc(&csr_offsets_d, (n + 1) * sizeof(int)),
+                        "cudaMalloc for csr_offsets");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&csr_columns_d, nnz * sizeof(int)),
+                        "cudaMalloc for csr_columns");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&csr_values_d, nnz * sizeof(double)),
+                        "cudaMalloc for csr_values");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&b_values_d, nrhs * n * sizeof(double)),
+                        "cudaMalloc for b_values");
+    CUDA_CALL_AND_CHECK(cudaMalloc(&x_values_d, nrhs * n * sizeof(double)),
+                        "cudaMalloc for x_values");
+
+    /* Copy host memory to device for A and b */
+    CUDA_CALL_AND_CHECK(cudaMemcpy(csr_offsets_d, csr_offsets_h, (n + 1) * sizeof(int),
+                                   cudaMemcpyHostToDevice),
+                        "cudaMemcpy for csr_offsets");
+    CUDA_CALL_AND_CHECK(cudaMemcpy(csr_columns_d, csr_columns_h, nnz * sizeof(int),
+                                   cudaMemcpyHostToDevice),
+                        "cudaMemcpy for csr_columns");
+    CUDA_CALL_AND_CHECK(cudaMemcpy(csr_values_d, csr_values_h, nnz * sizeof(double),
+                                   cudaMemcpyHostToDevice),
+                        "cudaMemcpy for csr_values");
+    CUDA_CALL_AND_CHECK(cudaMemcpy(b_values_d, b_values_h, nrhs * n * sizeof(double),
+                                   cudaMemcpyHostToDevice),
+                        "cudaMemcpy for b_values");
+
+    /* Create a CUDA stream */
+    cudaStream_t stream = NULL;
+    CUDA_CALL_AND_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    /* Creating the cuDSS library handle */
+    cudssHandle_t handle;
+
+    CUDSS_CALL_AND_CHECK(cudssCreate(&handle), status, "cudssCreate");
+
+    /* (optional) Setting the custom stream for the library handle */
+    CUDSS_CALL_AND_CHECK(cudssSetStream(handle, stream), status, "cudssSetStream");
+
+    /* Creating cuDSS solver configuration and data objects */
+    cudssConfig_t solverConfig;
+    cudssData_t solverData;
+
+    CUDSS_CALL_AND_CHECK(cudssConfigCreate(&solverConfig), status, "cudssConfigCreate");
+
+    /* (optional) Setting algorithmic knobs */
+    CUDSS_CALL_AND_CHECK(cudssConfigSet(solverConfig, CUDSS_CONFIG_REORDERING_ALG,
+                                        &reorder_alg, sizeof(cudssAlgType_t)),
+                         status, "cudssSolverSet");
+
+    CUDSS_CALL_AND_CHECK(cudssDataCreate(handle, &solverData), status, "cudssDataCreate");
+
+    /* Create matrix objects for the right-hand side b and solution x (as dense matrices). */
+    cudssMatrix_t x, b;
+
+    int64_t nrows = n, ncols = n;
+    int ldb = ncols, ldx = nrows;
+    CUDSS_CALL_AND_CHECK(cudssMatrixCreateDn(&b, ncols, nrhs, ldb, b_values_d, CUDA_R_64F,
+                                             CUDSS_LAYOUT_COL_MAJOR),
+                         status, "cudssMatrixCreateDn for b");
+    CUDSS_CALL_AND_CHECK(cudssMatrixCreateDn(&x, nrows, nrhs, ldx, x_values_d, CUDA_R_64F,
+                                             CUDSS_LAYOUT_COL_MAJOR),
+                         status, "cudssMatrixCreateDn for x");
+
+    /* Create a matrix object for the sparse input matrix. */
+    cudssMatrix_t A;
+    
+    printf("--- Start solving--- \n");
+    cudaEventRecord(start);
+    cudssIndexBase_t base = CUDSS_BASE_ZERO;
+    CUDSS_CALL_AND_CHECK(cudssMatrixCreateCsr(&A, nrows, ncols, nnz, csr_offsets_d, NULL,
+                                              csr_columns_d, csr_values_d, CUDA_R_32I, CUDA_R_64F, mtype, mview,
+                                              base),
+                         status, "cudssMatrixCreateCsr");
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&time_ms, start, stop);
+    printf("cuDSS MatrixCreateCsr time: %.4f ms\n", time_ms);
+    total_ms += time_ms;
+
+    /* Symbolic factorization */
+    cudaEventRecord(start);
+    CUDSS_CALL_AND_CHECK(cudssExecute(handle, CUDSS_PHASE_ANALYSIS, solverConfig, solverData,
+                                      A, x, b),
+                         status, "cudssExecute for analysis");
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&time_ms, start, stop);
+    printf("cuDSS Analysis time: %.4f ms\n", time_ms);
+    total_ms += time_ms;
+
+    /* Factorization */
+    cudaEventRecord(start);
+    CUDSS_CALL_AND_CHECK(cudssExecute(handle, CUDSS_PHASE_FACTORIZATION, solverConfig,
+                                      solverData, A, x, b),
+                         status, "cudssExecute for factor");
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&time_ms, start, stop);
+    printf("cuDSS Factorization time: %.4f ms\n", time_ms);
+    total_ms += time_ms;
+
+    /* Solving */
+    cudaEventRecord(start);
+    CUDSS_CALL_AND_CHECK(cudssExecute(handle, CUDSS_PHASE_SOLVE, solverConfig, solverData,
+                                      A, x, b),
+                         status, "cudssExecute for solve");
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&time_ms, start, stop);
+    printf("cuDSS Solve time: %.4f ms\n", time_ms);
+    total_ms += time_ms;
+
+
+    /* Print the solution and compare against the exact solution */
+    CUDA_CALL_AND_CHECK(cudaMemcpy(x_values_h, x_values_d, nrhs * n * sizeof(double), cudaMemcpyDeviceToHost), "cudaMemcpy for x_values");
+    
+    printf("--- Solving complete ! --- \n");
+    printf("cuDSS Total time: %.4f ms\n", total_ms);
+
+    double residual = compute_residual_error(n, csr_offsets_h, csr_columns_h, csr_values_h, x_values_h, b_values_h, mview);
+    
+    printf("Residual L2 error ||Ax - b|| = %e\n", residual);
+    bool passed = (residual < 1e-5);
+
+    /* Destroying opaque objects, matrix wrappers and the cuDSS library handle */
+    CUDSS_CALL_AND_CHECK(cudssMatrixDestroy(A), status, "cudssMatrixDestroy for A");
+    CUDSS_CALL_AND_CHECK(cudssMatrixDestroy(b), status, "cudssMatrixDestroy for b");
+    CUDSS_CALL_AND_CHECK(cudssMatrixDestroy(x), status, "cudssMatrixDestroy for x");
+    CUDSS_CALL_AND_CHECK(cudssDataDestroy(handle, solverData), status, "cudssDataDestroy");
+    CUDSS_CALL_AND_CHECK(cudssConfigDestroy(solverConfig), status, "cudssConfigDestroy");
+    CUDSS_CALL_AND_CHECK(cudssDestroy(handle), status, "cudssHandleDestroy");
+
+    CUDA_CALL_AND_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+    CUDSS_EXAMPLE_FREE;
+
+    if (status == CUDSS_STATUS_SUCCESS && passed)
+    {
+        printf("Example PASSED\n");
+        return 0;
+    }
+    else
+    {
+        printf("Example FAILED\n");
+        return -1;
+    }
+}

--- a/cuDSS/simple_matrix_market/simple_matrix_market.cpp
+++ b/cuDSS/simple_matrix_market/simple_matrix_market.cpp
@@ -36,11 +36,9 @@
         b is the (dense) right-hand side vector (or a matrix),
         x is the (dense) solution vector (or a matrix).
 
-    Example usage from build directory
-    ./simple_matrix_market_example 0 general full ../matrix.mtx ../rhs.mtx
 */
 
-double compute_residual_error(int n, const int *csr_offsets_h, const int *csr_columns_h,
+double compute_residual_abs_norm(int n, const int *csr_offsets_h, const int *csr_columns_h,
                               const double *csr_values_h, const double *x_values_h,
                               const double *b_values_h, cudssMatrixViewType_t mview) {
     std::vector<double> Ax(n, 0.0);
@@ -144,8 +142,11 @@ int main(int argc, char *argv[]) {
         fprintf(
             stderr,
             "Usage: %s <alg: 0|1|2|3> <mtype: general|symmetric|hermitian|spd|hpd> "
-            "<mview: full|lower|upper> <matrix_filename> [vector_filename (optional)]\n",
-            argv[0]);
+            "<mview: full|lower|upper> <matrix_filename> [vector_filename (optional)]\n"
+            "Suggested input to start with the sample .mtx files provided (from build folder):\n"
+            "    ./simple_matrix_market_example 0 spd upper ../matrix.mtx ../rhs.mtx\n",
+            argv[0]
+        );
         return EXIT_FAILURE;
     }
 
@@ -396,10 +397,22 @@ int main(int argc, char *argv[]) {
     printf("--- Solving complete ! --- \n");
     printf("cuDSS Total time: %.4f ms\n", total_ms);
 
-    double residual = compute_residual_error(n, csr_offsets_h, csr_columns_h,
+    /*
+     * Here we only compute the residual absolute norm. For estimating the accuracy
+     * of solving a linear system in practical cases, we recommend using a relative
+     * residual norm as demonstrated in a different sample called
+     * "simple_residual".
+     */
+    printf("\nComputing the residual (absolute) norm on the host for simplicity.\n");
+    printf("When using cuDSS in a production code, consider using a more standard approach\n");
+    printf("to estimate the accuracy of the solving. Please refer to the 'simple_residual' sample.\n");
+    printf("See: https://github.com/NVIDIA/CUDALibrarySamples/tree/main/cuDSS/simple_residual\n\n");
+
+    double residual = compute_residual_abs_norm(n, csr_offsets_h, csr_columns_h,
                                              csr_values_h, x_values_h, b_values_h, mview);
 
-    printf("Residual L2 error ||Ax - b|| = %e\n", residual);
+    printf("Residual L2 norm ||Ax - b|| = %e\n", residual);
+
     bool passed = (residual < 1e-5);
 
     /* Destroying opaque objects, matrix wrappers and the cuDSS library handle */


### PR DESCRIPTION
This PR implements the same new example as [this closed one](https://github.com/NVIDIA/CUDALibrarySamples/pull/264), but is aligned with the new contribution policy, namely commits are signed, and the target branch is `main`.

**Note 1:** I set the C++ standard to 17 in the CMakeLists.txt for this example

**Note 2:** I have not followed the update of cuDSS since the time I first wrote the example. Some hard coded rules I implemented  such as  _"algorithms 1 and 2 are only for non sym / non hermitian matrices"_ may no longer apply. I have not double checked yet

Summary of features, taken from [the previous PR ](https://github.com/NVIDIA/CUDALibrarySamples/pull/264):

 - Added timers to the different parts of the resolution
 - Compute the final error (on host), taking into account the view type
 - implemented a easy to use command line input
 ```bash
 Usage: ./binary <alg: 0|1|2|3> <mtype: general|symmetric|hermitian|spd|hpd> <mview: full|lower|upper> <matrix_filename> [vector_filename (optional)] 
For instance, to reproduce the simple example:
./binary 0 symmetric upper matrix.mtx rhs.mtx 
```
- Use a vector filled with 1 if no rhs is given
- Display a warnings if algs 1 or 2 are used with a mtype that is not general
- Display a warning if the mview is not 'full' while mtype is 'general'
- Throw a runtime error if the reader finds elements in the upper / lower part of the matrix and the mtype is lower / upper
- Throw a runtime error if the reader does not find elements in both upper / lower parts of the matrix and the mview is full.
- We accept unsorted entries, and will sort them with std::sort, as well as empty rows.
- The reader does a small mock allocation if no file is found so that subsequent free operations don't fail.
- Throws an error if nnz in the header is != to the # of elements in the mtx file
- Throws an error is read i,j are out of bound i.e <0, or >= n
- Display a warning for empty rows (maybe its a bit too much)
- add a verbose mode for infos and errors

The whole thing can be unit tested as I did locally [here](https://github.com/rbourgeois33/my-cudss-input-deck/blob/main/unit_test_matrix_reader.cpp), but I dont wan't to add tests to this Sample set repo.

Thanks again @kvoronin for figuring out the legal details. Let me know if I can do anything else from here. Happy to help.

Cheers
