### PR TITLE
doc: update cuBLAS emulation prerequisites, executable name

### DIFF
--- a/cuBLAS/Emulation/dgemm_dynamic/README.md
+++ b/cuBLAS/Emulation/dgemm_dynamic/README.md
@@ -40,7 +40,8 @@ arm64-sbsa
 # Building (make)
 
 # Prerequisites
-- A Linux/Windows system with recent NVIDIA drivers minimum 580.95.05 and CUDA 13.0 Release 2.
+- A Linux/Windows system with recent NVIDIA drivers (r580+)
+- CUDA Toolkit 13.0 Update 2 or newer
 - [CMake](https://cmake.org/download) version 3.18 minimum
 
 ## Build command on Linux

--- a/cuBLAS/Emulation/dgemm_fixed/README.md
+++ b/cuBLAS/Emulation/dgemm_fixed/README.md
@@ -40,7 +40,8 @@ arm64-sbsa
 # Building (make)
 
 # Prerequisites
-- A Linux/Windows system with recent NVIDIA drivers minimum 580.95.05 and CUDA 13.0 Release 2.
+- A Linux/Windows system with recent NVIDIA drivers (r580+)
+- CUDA Toolkit 13.0 Update 2 or newer
 - [CMake](https://cmake.org/download) version 3.18 minimum
 
 ## Build command on Linux

--- a/cuBLAS/Emulation/gemmEx_dynamic/README.md
+++ b/cuBLAS/Emulation/gemmEx_dynamic/README.md
@@ -40,7 +40,8 @@ arm64-sbsa
 # Building (make)
 
 # Prerequisites
-- A Linux/Windows system with recent NVIDIA drivers minimum 580.95.05 and CUDA 13.0 Release 2.
+- A Linux/Windows system with recent NVIDIA drivers (r580+)
+- CUDA Toolkit 13.0 Update 2 or newer
 - [CMake](https://cmake.org/download) version 3.18 minimum
 
 ## Build command on Linux

--- a/cuBLAS/Emulation/gemmEx_fixed/README.md
+++ b/cuBLAS/Emulation/gemmEx_fixed/README.md
@@ -40,7 +40,8 @@ arm64-sbsa
 # Building (make)
 
 # Prerequisites
-- A Linux/Windows system with recent NVIDIA drivers minimum 580.95.05 and CUDA 13.0 Release 2.
+- A Linux/Windows system with recent NVIDIA drivers (r580+)
+- CUDA Toolkit 13.0 Update 2 or newer
 - [CMake](https://cmake.org/download) version 3.18 minimum
 
 ## Build command on Linux

--- a/cuBLAS/Emulation/zgemm_dynamic/README.md
+++ b/cuBLAS/Emulation/zgemm_dynamic/README.md
@@ -40,7 +40,8 @@ arm64-sbsa
 # Building (make)
 
 # Prerequisites
-- A Linux/Windows system with recent NVIDIA drivers minimum 580.95.05 and CUDA 13.0 Release 2.
+- A Linux/Windows system with recent NVIDIA drivers (r580+)
+- CUDA Toolkit 13.0 Update 2 or newer
 - [CMake](https://cmake.org/download) version 3.18 minimum
 
 ## Build command on Linux

--- a/cuBLAS/Emulation/zgemm_fixed/README.md
+++ b/cuBLAS/Emulation/zgemm_fixed/README.md
@@ -40,7 +40,8 @@ arm64-sbsa
 # Building (make)
 
 # Prerequisites
-- A Linux/Windows system with recent NVIDIA drivers minimum 580.95.05 and CUDA 13.0 Release 2.
+- A Linux/Windows system with recent NVIDIA drivers (r580+)
+- CUDA Toolkit 13.0 Update 2 or newer
 - [CMake](https://cmake.org/download) version 3.18 minimum
 
 ## Build command on Linux


### PR DESCRIPTION
Specified CUDA prerequisite, given that this is a very recent release and may require user to update. Also, some executable paths specified are slightly incorrect, so I update those to reduce confusion. I suspect that the `*_dynamic` examples also have wrong path, but I am unable to build these as elaborated in #293.