### PR TITLE
Fix RNG type in mtgp32 uniform cuRAND example

### DIFF
--- a/cuRAND/Host/mtgp32/curand_mtgp32_poisson_example.cpp
+++ b/cuRAND/Host/mtgp32/curand_mtgp32_poisson_example.cpp
@@ -44,7 +44,7 @@ void run_on_device(const int &n, const unsigned long long &seed,
                         sizeof(data_type) * h_data.size()));
 
   /* Create pseudo-random number generator */
-  CURAND_CHECK(curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_MT19937));
+  CURAND_CHECK(curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_MTGP32));
 
   /* Set cuRAND to stream */
   CURAND_CHECK(curandSetStream(gen, stream));
@@ -77,7 +77,7 @@ void run_on_host(const int &n, const unsigned long long &seed,
                  curandGenerator_t &gen, std::vector<data_type> &h_data) {
 
   /* Create pseudo-random number generator */
-  CURAND_CHECK(curandCreateGeneratorHost(&gen, CURAND_RNG_PSEUDO_MT19937));
+  CURAND_CHECK(curandCreateGeneratorHost(&gen, CURAND_RNG_PSEUDO_MTGP32));
 
   /* Set cuRAND to stream */
   CURAND_CHECK(curandSetStream(gen, stream));
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
 
   cudaStream_t stream = NULL;
   curandGenerator_t gen = NULL;
-  curandRngType_t rng = CURAND_RNG_PSEUDO_MT19937;
+  curandRngType_t rng = CURAND_RNG_PSEUDO_MTGP32;
   curandOrdering_t order = CURAND_ORDERING_PSEUDO_DEFAULT;
 
   const int n = 10;

--- a/cuRAND/Host/mtgp32/curand_mtgp32_uniform_example.cpp
+++ b/cuRAND/Host/mtgp32/curand_mtgp32_uniform_example.cpp
@@ -44,7 +44,7 @@ void run_on_device(const int &n, const unsigned long long &seed,
                         sizeof(data_type) * h_data.size()));
 
   /* Create pseudo-random number generator */
-  CURAND_CHECK(curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_MRG32K3A));
+  CURAND_CHECK(curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_MTGP32));
 
   /* Set cuRAND to stream */
   CURAND_CHECK(curandSetStream(gen, stream));
@@ -76,7 +76,7 @@ void run_on_host(const int &n, const unsigned long long &seed,
                  std::vector<data_type> &h_data) {
 
   /* Create pseudo-random number generator */
-  CURAND_CHECK(curandCreateGeneratorHost(&gen, CURAND_RNG_PSEUDO_MRG32K3A));
+  CURAND_CHECK(curandCreateGeneratorHost(&gen, CURAND_RNG_PSEUDO_MTGP32));
 
   /* Set cuRAND to stream */
   CURAND_CHECK(curandSetStream(gen, stream));
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
 
   cudaStream_t stream = NULL;
   curandGenerator_t gen = NULL;
-  curandRngType_t rng = CURAND_RNG_PSEUDO_MRG32K3A;
+  curandRngType_t rng = CURAND_RNG_PSEUDO_MTGP32;
   curandOrdering_t order = CURAND_ORDERING_PSEUDO_BEST;
 
   const int n = 10;

--- a/cuRAND/Host/scrambled_sobol32/curand_scrambled_sobol32_poisson_example.cpp
+++ b/cuRAND/Host/scrambled_sobol32/curand_scrambled_sobol32_poisson_example.cpp
@@ -45,7 +45,7 @@ void run_on_device(const int &n, const unsigned long long &offset,
                         sizeof(data_type) * h_data.size()));
 
   /* Create quasi-random number generator */
-  CURAND_CHECK(curandCreateGenerator(&gen, CURAND_RNG_QUASI_SCRAMBLED_SOBOL64));
+  CURAND_CHECK(curandCreateGenerator(&gen, CURAND_RNG_QUASI_SCRAMBLED_SOBOL32));
 
   /* Set cuRAND to stream */
   CURAND_CHECK(curandSetStream(gen, stream));
@@ -83,7 +83,7 @@ void run_on_host(const int &n, const unsigned long long &offset,
 
   /* Create quasi-random number generator */
   CURAND_CHECK(
-      curandCreateGeneratorHost(&gen, CURAND_RNG_QUASI_SCRAMBLED_SOBOL64));
+      curandCreateGeneratorHost(&gen, CURAND_RNG_QUASI_SCRAMBLED_SOBOL32));
 
   /* Set cuRAND to stream */
   CURAND_CHECK(curandSetStream(gen, stream));
@@ -109,7 +109,7 @@ int main(int argc, char *argv[]) {
 
   cudaStream_t stream = NULL;
   curandGenerator_t gen = NULL;
-  curandRngType_t rng = CURAND_RNG_QUASI_SCRAMBLED_SOBOL64;
+  curandRngType_t rng = CURAND_RNG_QUASI_SCRAMBLED_SOBOL32;
   curandOrdering_t order = CURAND_ORDERING_QUASI_DEFAULT;
 
   const int n = 10;


### PR DESCRIPTION
Fixes #146

## Summary

Three cuRAND Host API examples create a generator type that does not match the generator they are documented to demonstrate. Each one runs without error because the substituted generator is valid for the requested distribution, but the mismatch is invisible at runtime and silently misleads anyone who copies the example.

| File | Documented generator | Was using |
| ---- | -------------------- | --------- |
| `cuRAND/Host/mtgp32/curand_mtgp32_uniform_example.cpp` | MTGP32 | `CURAND_RNG_PSEUDO_MRG32K3A` |
| `cuRAND/Host/mtgp32/curand_mtgp32_poisson_example.cpp` | MTGP32 | `CURAND_RNG_PSEUDO_MT19937` |
| `cuRAND/Host/scrambled_sobol32/curand_scrambled_sobol32_poisson_example.cpp` | scrambled Sobol32 | `CURAND_RNG_QUASI_SCRAMBLED_SOBOL64` |

## Why this is a bug

The documented intent comes from three places for every file: the file name, the folder README (e.g. "generate MTGP32 pseudorandom generated numbers"), and the cuRAND index (e.g. "uniform mtgp32 pseudorandom generation using Host API"). Because the wrongly used generators are still valid and produce the same distribution shape, the samples build and run cleanly — this is the same class of issue as #146, where the maintainer asked "MRG32K3A is a valid generator type, what is the issue?" and the reporter had to clarify that the sample is named `mtgp32`.

The `mtgp32_poisson` change was requested in the review of this PR.

## Change

For each file, all three generator-construction sites are updated consistently: the device path (`curandCreateGenerator`), the host path (`curandCreateGeneratorHost`), and the `rng` variable in `main()`.

- `curand_mtgp32_uniform_example.cpp`: `MRG32K3A` → `CURAND_RNG_PSEUDO_MTGP32`
- `curand_mtgp32_poisson_example.cpp`: `MT19937` → `CURAND_RNG_PSEUDO_MTGP32`
- `curand_scrambled_sobol32_poisson_example.cpp`: `SOBOL64` → `CURAND_RNG_QUASI_SCRAMBLED_SOBOL32`

This matches the sibling examples (`curand_mtgp32_normal_example.cpp`, `curand_mtgp32_lognormal_example.cpp`, and the other `scrambled_sobol32` samples), which already use the correct generator type in the same three places.

## Testing

- Built with CUDA 13.2 on Linux x86_64.
- Ran on NVIDIA GeForce RTX 4060 Laptop GPU (sm_89).
- All four `mtgp32` examples and the `scrambled_sobol32_poisson` example build and run with matching host and device output.
- Before the change, the SOBOL64 + Poisson combination was run as a baseline to confirm the quasi-random + Poisson path is supported.